### PR TITLE
Implement FSM screen navigation

### DIFF
--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -1,0 +1,13 @@
+import * as PIXI from 'pixi.js';
+import { GameStateStore } from './GameStateStore.js';
+import { StateManager } from './StateManager.js';
+
+export const store = new GameStateStore();
+
+export const app = new PIXI.Application({
+  resizeTo: window,
+  backgroundColor: 0x000000,
+  antialias: true,
+});
+
+export const stateManager = new StateManager(store, app);

--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -1,6 +1,10 @@
 export class GameStateStore {
   constructor() {
-    this.state = {};
+    // runtime navigation state stored here
+    this.state = {
+      currentScreen: null,
+      navStack: [],
+    };
     this.listeners = new Map();
   }
 

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -1,12 +1,53 @@
+import { MainScreen } from '../screens/MainScreen.js';
+import { GalaxyMap } from '../screens/GalaxyMap.js';
+import { Profile } from '../screens/Profile.js';
+import { Store } from '../screens/Store.js';
+import { Earn } from '../screens/Earn.js';
+import { Friends } from '../screens/Friends.js';
+
+const registry = {
+  MainScreen,
+  GalaxyMap,
+  Profile,
+  Store,
+  Earn,
+  Friends,
+};
+
 export class StateManager {
-  constructor(store) {
+  constructor(store, app) {
     this.store = store;
-    this.current = null;
+    this.app = app;
+    this.stack = [];
   }
 
-  changeState(name, params) {
-    console.log('State change ->', name, params);
-    this.current = name;
-    this.store.set({ currentScreen: name });
+  goTo(name, params) {
+    const ScreenClass = registry[name];
+    if (!ScreenClass) return console.warn('Unknown screen', name);
+
+    const screen = new ScreenClass(this.app, this, params);
+    if (this.current) {
+      this.app.stage.removeChild(this.current);
+    }
+    this.stack.push(screen);
+    this.current = screen;
+    this.app.stage.addChild(screen);
+    this.store.set({
+      currentScreen: name,
+      navStack: this.stack.map((s) => s.screenId),
+    });
+  }
+
+  goBack() {
+    if (this.stack.length <= 1) return;
+    const old = this.stack.pop();
+    this.app.stage.removeChild(old);
+    if (old.destroy) old.destroy({ children: true });
+    this.current = this.stack[this.stack.length - 1];
+    this.app.stage.addChild(this.current);
+    this.store.set({
+      currentScreen: this.current.screenId,
+      navStack: this.stack.map((s) => s.screenId),
+    });
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,9 @@
 import './style.css';
-import * as PIXI from 'pixi.js';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { GameStateStore } from './core/GameStateStore.js';
-import { StateManager } from './core/StateManager.js';
+import { app, stateManager } from './core/GameEngine.js';
 import { DevPanel } from './ui/DevPanel.tsx';
-
-const store = new GameStateStore();
-const stateManager = new StateManager(store);
-
-const app = new PIXI.Application({
-  resizeTo: window,
-  backgroundColor: 0x000000,
-  antialias: true,
-});
+import { BottomNavBar } from './ui/BottomNavBar.tsx';
 
 const canvasElem = document.getElementById('game-canvas');
 canvasElem.replaceWith(app.view);
@@ -21,17 +11,12 @@ app.view.id = 'game-canvas';
 
 document.body.appendChild(app.view);
 
-const hello = new PIXI.Text('Hello World', { fill: 'white' });
-hello.anchor.set(0.5);
-hello.x = window.innerWidth / 2;
-hello.y = window.innerHeight / 2;
-app.stage.addChild(hello);
 
 function UI() {
   return (
-    <div className="absolute inset-0 flex items-start justify-center pointer-events-none">
-      <button className="m-4 px-4 py-2 bg-blue-500 text-white pointer-events-auto">UI Button</button>
+    <div className="absolute inset-0 flex flex-col justify-end pointer-events-none">
       <DevPanel />
+      <BottomNavBar />
     </div>
   );
 }
@@ -39,5 +24,5 @@ function UI() {
 const root = ReactDOM.createRoot(document.getElementById('ui-layer'));
 root.render(<UI />);
 
-stateManager.changeState('hello');
+stateManager.goTo('MainScreen');
 

--- a/src/screens/Earn.js
+++ b/src/screens/Earn.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class Earn extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'Earn';
+    const label = new PIXI.Text('Earn Screen', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/screens/Friends.js
+++ b/src/screens/Friends.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class Friends extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'Friends';
+    const label = new PIXI.Text('Friends Screen', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/screens/GalaxyMap.js
+++ b/src/screens/GalaxyMap.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class GalaxyMap extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'GalaxyMap';
+    const label = new PIXI.Text('Galaxy Map', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class MainScreen extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'MainScreen';
+    const label = new PIXI.Text('Main Screen', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class Profile extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'Profile';
+    const label = new PIXI.Text('Profile Screen', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/screens/Store.js
+++ b/src/screens/Store.js
@@ -1,0 +1,22 @@
+import * as PIXI from 'pixi.js';
+
+export class Store extends PIXI.Container {
+  constructor(app, manager) {
+    super();
+    this.screenId = 'Store';
+    const label = new PIXI.Text('Store Screen', { fill: 'white' });
+    label.anchor.set(0.5);
+    label.x = app.renderer.width / 2;
+    label.y = app.renderer.height / 2;
+    this.addChild(label);
+
+    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
+    backBtn.interactive = true;
+    backBtn.buttonMode = true;
+    backBtn.anchor.set(0.5);
+    backBtn.x = app.renderer.width / 2;
+    backBtn.y = app.renderer.height - 60;
+    backBtn.on('pointertap', () => manager.goBack());
+    this.addChild(backBtn);
+  }
+}

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { stateManager } from '../core/GameEngine.js';
+
+const buttons = [
+  { id: 'Profile', label: 'Profile' },
+  { id: 'Store', label: 'Store' },
+  { id: 'MainScreen', label: 'Main' },
+  { id: 'Earn', label: 'Earn' },
+  { id: 'Friends', label: 'Friends' },
+];
+
+export const BottomNavBar = () => {
+  return (
+    <div className="absolute bottom-0 left-0 right-0 flex justify-around bg-gray-800 text-white z-50 pointer-events-auto">
+      {buttons.map((btn) => (
+        <button
+          key={btn.id}
+          className="flex-1 py-2"
+          onClick={() => stateManager.goTo(btn.id)}
+        >
+          {btn.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { isProd } from '../data/BuildFlags.js';
+import { stateManager } from '../core/GameEngine.js';
+
+const screens = ['MainScreen', 'GalaxyMap', 'Profile', 'Store', 'Earn', 'Friends'];
 
 export const DevPanel = () => {
   if (isProd) return null;
@@ -10,6 +13,17 @@ export const DevPanel = () => {
         <button className="bg-blue-500 px-2 py-1">Skip Ads</button>
         <button className="bg-blue-500 px-2 py-1">Unlock Screens</button>
         <button className="bg-blue-500 px-2 py-1">Force Nebula</button>
+        <div className="flex flex-wrap space-x-1 mt-2">
+          {screens.map((s) => (
+            <button
+              key={s}
+              className="bg-purple-600 px-2 py-1 mt-1"
+              onClick={() => stateManager.goTo(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add runtime nav state to `GameStateStore`
- implement `StateManager` with screen stack and transitions
- create `GameEngine` singleton for Pixi application and manager
- add placeholder screens for `MainScreen`, `GalaxyMap`, `Profile`, `Store`, `Earn`, and `Friends`
- implement `BottomNavBar` for navigation
- extend `DevPanel` with teleporter buttons
- update `main.tsx` to bootstrap Pixi and start at `MainScreen`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863ea75f1508322b38522dc19ec4df9