### PR TITLE
Add playable MainScreen with attack loop

### DIFF
--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -4,6 +4,18 @@ export class GameStateStore {
     this.state = {
       currentScreen: null,
       navStack: [],
+      planet: {
+        name: 'Alpha',
+        hp: 100,
+        maxHp: 100,
+        destroyed: false,
+        coreExtractable: false,
+      },
+      resources: {
+        dust: 0,
+        cores: 0,
+        magmaton: 0,
+      },
     };
     this.listeners = new Map();
   }
@@ -22,7 +34,45 @@ export class GameStateStore {
     this.listeners.get(event).push(cb);
   }
 
+  off(event, cb) {
+    const arr = this.listeners.get(event) || [];
+    const idx = arr.indexOf(cb);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
   emit(event, data) {
     (this.listeners.get(event) || []).forEach((cb) => cb(data));
+  }
+
+  addDust(amount, source = 'attack') {
+    this.state.resources.dust += amount;
+    this.emit('reward:dust', { amount, source });
+    this.emit('update', this.state);
+  }
+
+  addCore(amount, source = 'dispatch') {
+    this.state.resources.cores += amount;
+    this.emit('reward:core', { amount, source });
+    this.emit('update', this.state);
+  }
+
+  damagePlanet(amount) {
+    const p = this.state.planet;
+    if (p.destroyed) return;
+    p.hp -= amount;
+    if (p.hp <= 0) {
+      p.hp = 0;
+      p.destroyed = true;
+      p.coreExtractable = true;
+    }
+    this.emit('update', this.state);
+  }
+
+  resetPlanet() {
+    const p = this.state.planet;
+    p.hp = p.maxHp;
+    p.destroyed = false;
+    p.coreExtractable = false;
+    this.emit('update', this.state);
   }
 }

--- a/src/core/PlanetInteraction.js
+++ b/src/core/PlanetInteraction.js
@@ -1,0 +1,10 @@
+import { store } from './GameEngine.js';
+
+export const PlanetInteraction = {
+  attack(damage) {
+    store.damagePlanet(damage);
+  },
+  reset() {
+    store.resetPlanet();
+  },
+};

--- a/src/core/WeaponSystem.js
+++ b/src/core/WeaponSystem.js
@@ -1,0 +1,30 @@
+import { store } from './GameEngine.js';
+
+class WeaponSystem {
+  constructor() {
+    this.weapon = {
+      damage: 10,
+      ammo: 10,
+      ammoMax: 10,
+    };
+  }
+
+  fire() {
+    if (this.weapon.ammo <= 0) return false;
+    if (store.state.planet.destroyed) return false;
+    this.weapon.ammo -= 1;
+    store.damagePlanet(this.weapon.damage);
+    store.addDust(1, 'attack');
+    return true;
+  }
+
+  addAmmo(amount) {
+    this.weapon.ammo = Math.min(
+      this.weapon.ammo + amount,
+      this.weapon.ammoMax
+    );
+    store.emit('update', store.state);
+  }
+}
+
+export const weaponSystem = new WeaponSystem();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,13 @@
 import './style.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { app, stateManager } from './core/GameEngine.js';
+import { app, stateManager, store } from './core/GameEngine.js';
 import { DevPanel } from './ui/DevPanel.tsx';
 import { BottomNavBar } from './ui/BottomNavBar.tsx';
+import { CurrencyHUD } from './ui/CurrencyHUD.tsx';
+import { WeaponPanel } from './ui/WeaponPanel.tsx';
+import { RewardDustPopup } from './ui/RewardDustPopup.tsx';
+import { RewardCorePopup } from './ui/RewardCorePopup.tsx';
 
 const canvasElem = document.getElementById('game-canvas');
 canvasElem.replaceWith(app.view);
@@ -13,8 +17,30 @@ document.body.appendChild(app.view);
 
 
 function UI() {
+  const [dustReward, setDustReward] = React.useState<number | null>(null);
+  const [coreReward, setCoreReward] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    const dustCb = ({ amount }: any) => setDustReward(amount);
+    const coreCb = ({ amount }: any) => setCoreReward(amount);
+    store.on('reward:dust', dustCb);
+    store.on('reward:core', coreCb);
+    return () => {
+      store.off('reward:dust', dustCb);
+      store.off('reward:core', coreCb);
+    };
+  }, []);
+
   return (
     <div className="absolute inset-0 flex flex-col justify-end pointer-events-none">
+      <CurrencyHUD />
+      <WeaponPanel />
+      {dustReward !== null && (
+        <RewardDustPopup amount={dustReward} onClose={() => setDustReward(null)} />
+      )}
+      {coreReward !== null && (
+        <RewardCorePopup amount={coreReward} onClose={() => setCoreReward(null)} />
+      )}
       <DevPanel />
       <BottomNavBar />
     </div>

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -1,22 +1,58 @@
 import * as PIXI from 'pixi.js';
+import { store } from '../core/GameEngine.js';
 
 export class MainScreen extends PIXI.Container {
-  constructor(app, manager) {
+  constructor(app) {
     super();
     this.screenId = 'MainScreen';
-    const label = new PIXI.Text('Main Screen', { fill: 'white' });
-    label.anchor.set(0.5);
-    label.x = app.renderer.width / 2;
-    label.y = app.renderer.height / 2;
-    this.addChild(label);
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
+    const { width, height } = app.renderer;
+
+    this.planetContainer = new PIXI.Container();
+    this.planetContainer.x = width / 2;
+    this.planetContainer.y = height * 0.4;
+    this.addChild(this.planetContainer);
+
+    this.planetGraphic = new PIXI.Graphics();
+    this.planetContainer.addChild(this.planetGraphic);
+
+    this.hpBg = new PIXI.Graphics();
+    this.hpBg.beginFill(0x333333);
+    this.hpBg.drawRect(-80, -90, 160, 10);
+    this.hpBg.endFill();
+    this.planetContainer.addChild(this.hpBg);
+
+    this.hpBar = new PIXI.Graphics();
+    this.planetContainer.addChild(this.hpBar);
+
+    this.nameLabel = new PIXI.Text('', { fill: 'white', fontSize: 14 });
+    this.nameLabel.anchor.set(0.5);
+    this.nameLabel.y = -110;
+    this.planetContainer.addChild(this.nameLabel);
+
+    this.updateView(store.get());
+    this.listener = (state) => this.updateView(state);
+    store.on('update', this.listener);
+  }
+
+  updateView(state) {
+    const p = state.planet;
+    this.planetGraphic.clear();
+    this.planetGraphic.beginFill(p.destroyed ? 0x555555 : 0x8888ff);
+    this.planetGraphic.drawCircle(0, 0, 70);
+    this.planetGraphic.endFill();
+
+    const ratio = p.hp / p.maxHp;
+    this.hpBar.clear();
+    this.hpBar.beginFill(0xff4444);
+    this.hpBar.drawRect(-80, -90, 160 * ratio, 10);
+    this.hpBar.endFill();
+
+    this.nameLabel.text = p.name;
+  }
+
+  destroy(opts) {
+    store.off('update', this.listener);
+    super.destroy(opts);
   }
 }

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { store } from '../core/GameEngine.js';
+
+export const CurrencyHUD = () => {
+  const [res, setRes] = useState(store.get().resources);
+
+  useEffect(() => {
+    const cb = (s: any) => setRes({ ...s.resources });
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
+  return (
+    <div className="absolute top-0 left-0 right-0 flex justify-around text-white text-sm pointer-events-auto">
+      <span>Dust: {res.dust}</span>
+      <span>Cores: {res.cores}</span>
+      <span>Magmaton: {res.magmaton}</span>
+    </div>
+  );
+};

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { isProd } from '../data/BuildFlags.js';
-import { stateManager } from '../core/GameEngine.js';
+import { stateManager, store } from '../core/GameEngine.js';
 
 const screens = ['MainScreen', 'GalaxyMap', 'Profile', 'Store', 'Earn', 'Friends'];
 
@@ -9,10 +9,27 @@ export const DevPanel = () => {
   return (
     <div className="fixed bottom-0 right-0 z-[400] p-2 pointer-events-auto">
       <div className="bg-gray-800 text-white p-2 rounded flex flex-col space-y-1">
-        <button className="bg-blue-500 px-2 py-1">Add Dust</button>
-        <button className="bg-blue-500 px-2 py-1">Skip Ads</button>
-        <button className="bg-blue-500 px-2 py-1">Unlock Screens</button>
-        <button className="bg-blue-500 px-2 py-1">Force Nebula</button>
+        <button
+          className="bg-blue-500 px-2 py-1"
+          onClick={() => store.addDust(100, 'dev')}
+        >
+          Add Dust
+        </button>
+        <button
+          className="bg-blue-500 px-2 py-1"
+          onClick={() => store.resetPlanet()}
+        >
+          Reset HP
+        </button>
+        <button
+          className="bg-blue-500 px-2 py-1"
+          onClick={() => {
+            store.addCore(1, 'dev');
+            store.resetPlanet();
+          }}
+        >
+          Instant Dispatch
+        </button>
         <div className="flex flex-wrap space-x-1 mt-2">
           {screens.map((s) => (
             <button

--- a/src/ui/ModalButton.tsx
+++ b/src/ui/ModalButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface Props {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  styleType?: 'primary' | 'secondary' | 'destructive';
+}
+
+export const ModalButton = ({ label, onClick, disabled, styleType = 'primary' }: Props) => {
+  const base =
+    styleType === 'destructive'
+      ? 'bg-red-600'
+      : styleType === 'secondary'
+      ? 'bg-gray-500'
+      : 'bg-blue-600';
+  return (
+    <button
+      className={`${base} text-white w-full py-2 rounded disabled:opacity-50`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {label}
+    </button>
+  );
+};

--- a/src/ui/RewardCorePopup.tsx
+++ b/src/ui/RewardCorePopup.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  amount: number;
+  onClose: () => void;
+}
+
+export const RewardCorePopup = ({ amount, onClose }: Props) => {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-[200] pointer-events-auto">
+      <div className="bg-gray-800 text-white p-4 rounded text-center w-3/4 max-w-xs">
+        <div className="text-lg mb-2">Core Acquired</div>
+        <div className="text-2xl mb-4">+{amount}</div>
+        <button
+          className="bg-blue-600 w-full py-2 rounded"
+          onClick={onClose}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/RewardDustPopup.tsx
+++ b/src/ui/RewardDustPopup.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  amount: number;
+  onClose: () => void;
+}
+
+export const RewardDustPopup = ({ amount, onClose }: Props) => {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-[200] pointer-events-auto">
+      <div className="bg-gray-800 text-white p-4 rounded text-center w-3/4 max-w-xs">
+        <div className="text-lg mb-2">Cosmic Dust Received</div>
+        <div className="text-2xl mb-4">+{amount}</div>
+        <button
+          className="bg-blue-600 w-full py-2 rounded"
+          onClick={onClose}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { weaponSystem } from '../core/WeaponSystem.js';
+import { store } from '../core/GameEngine.js';
+
+export const WeaponPanel = () => {
+  const [ammo, setAmmo] = useState(weaponSystem.weapon.ammo);
+  const [planet, setPlanet] = useState(store.get().planet);
+
+  useEffect(() => {
+    const upd = () => setAmmo(weaponSystem.weapon.ammo);
+    const planetCb = (s: any) => setPlanet({ ...s.planet });
+    store.on('update', planetCb);
+    store.on('update', upd);
+    return () => {
+      store.off('update', planetCb);
+      store.off('update', upd);
+    };
+  }, []);
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 flex flex-col items-center space-y-2 pb-4 pointer-events-auto">
+      <div className="text-white text-sm">Ammo: {ammo}</div>
+      {!planet.destroyed && (
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          onClick={() => {
+            weaponSystem.fire();
+            setAmmo(weaponSystem.weapon.ammo);
+          }}
+        >
+          Attack
+        </button>
+      )}
+      {planet.coreExtractable && (
+        <button
+          className="bg-green-600 text-white px-4 py-2 rounded"
+          onClick={() => {
+            store.addCore(1, 'dispatch');
+            store.resetPlanet();
+          }}
+        >
+          Send Unit
+        </button>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- implement expanded GameStateStore with planet state and resources
- add simple WeaponSystem and PlanetInteraction modules
- create new MainScreen with planet graphics and HP bar
- show currencies and weapons via React UI
- add reward popups and dev tools

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863f8b560248322b32fc36df28ef90c