### PR TITLE
Implement mobile layout wrapper and UI overhaul

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -1,5 +1,13 @@
 {
   "ui": {
-    "placeholder": "ui/placeholder.svg"
+    "placeholder": "ui/placeholder.svg",
+    "iconDust": "ui/icon-dust.svg",
+    "iconCore": "ui/icon-core.svg",
+    "iconMagmaton": "ui/icon-magmaton.svg",
+    "navProfile": "ui/nav-profile.svg",
+    "navStore": "ui/nav-store.svg",
+    "navMain": "ui/nav-main.svg",
+    "navEarn": "ui/nav-earn.svg",
+    "navFriends": "ui/nav-friends.svg"
   }
 }

--- a/assets/ui/icon-core.svg
+++ b/assets/ui/icon-core.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#ffcc00"/>
+  <text x="24" y="30" font-size="24" text-anchor="middle" fill="#000">C</text>
+</svg>

--- a/assets/ui/icon-dust.svg
+++ b/assets/ui/icon-dust.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#d4bfff"/>
+  <text x="24" y="30" font-size="24" text-anchor="middle" fill="#000">D</text>
+</svg>

--- a/assets/ui/icon-magmaton.svg
+++ b/assets/ui/icon-magmaton.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#88e0f0"/>
+  <text x="24" y="30" font-size="24" text-anchor="middle" fill="#000">M</text>
+</svg>

--- a/assets/ui/nav-earn.svg
+++ b/assets/ui/nav-earn.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <polygon points="24,8 40,40 8,40" fill="#777" />
+</svg>

--- a/assets/ui/nav-friends.svg
+++ b/assets/ui/nav-friends.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="16" cy="20" r="8" fill="#777" />
+  <circle cx="32" cy="20" r="8" fill="#999" />
+  <rect x="8" y="30" width="32" height="10" fill="#777" />
+</svg>

--- a/assets/ui/nav-main.svg
+++ b/assets/ui/nav-main.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="20" fill="#555" />
+</svg>

--- a/assets/ui/nav-profile.svg
+++ b/assets/ui/nav-profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="16" r="10" fill="#777" />
+  <rect x="10" y="28" width="28" height="14" fill="#777" />
+</svg>

--- a/assets/ui/nav-store.svg
+++ b/assets/ui/nav-store.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <rect x="10" y="14" width="28" height="20" fill="#777" />
+  <rect x="8" y="12" width="32" height="4" fill="#aaa" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -12,27 +12,38 @@
       width: 100%;
       height: 100%;
       background: black;
-      overflow: hidden;
+      overflow-x: hidden;
       touch-action: none;
       -webkit-user-select: none;
       user-select: none;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
-    #game-canvas {
-      position: fixed;
+    #wrapper {
+      width: 100%;
+      max-width: 414px;
+      min-width: 360px;
+      aspect-ratio: 9 / 16;
+      position: relative;
+      margin: auto;
+      background: radial-gradient(circle at 50% 20%, #111, #000);
+    }
+    #game-canvas, #ui-layer {
+      position: absolute;
       inset: 0;
-      z-index: 0;
     }
     #ui-layer {
-      position: fixed;
-      inset: 0;
-      z-index: 10;
       pointer-events: none;
+      z-index: 10;
     }
   </style>
 </head>
 <body>
-  <canvas id="game-canvas"></canvas>
-  <div id="ui-layer"></div>
+  <div id="wrapper">
+    <canvas id="game-canvas"></canvas>
+    <div id="ui-layer"></div>
+  </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,8 +13,6 @@ const canvasElem = document.getElementById('game-canvas');
 canvasElem.replaceWith(app.view);
 app.view.id = 'game-canvas';
 
-document.body.appendChild(app.view);
-
 
 function UI() {
   const [dustReward, setDustReward] = React.useState<number | null>(null);

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -2,25 +2,26 @@ import React from 'react';
 import { stateManager } from '../core/GameEngine.js';
 
 const buttons = [
-  { id: 'Profile', label: 'Profile' },
-  { id: 'Store', label: 'Store' },
-  { id: 'MainScreen', label: 'Main' },
-  { id: 'Earn', label: 'Earn' },
-  { id: 'Friends', label: 'Friends' },
+  { id: 'Profile', label: 'Profile', icon: '/assets/ui/nav-profile.svg' },
+  { id: 'Store', label: 'Store', icon: '/assets/ui/nav-store.svg' },
+  { id: 'MainScreen', label: 'Main', icon: '/assets/ui/nav-main.svg' },
+  { id: 'Earn', label: 'Earn', icon: '/assets/ui/nav-earn.svg' },
+  { id: 'Friends', label: 'Friends', icon: '/assets/ui/nav-friends.svg' },
 ];
 
 export const BottomNavBar = () => {
   return (
-    <div className="absolute bottom-0 left-0 right-0 flex justify-around bg-gray-800 text-white z-50 pointer-events-auto">
+    <nav className="fixed bottom-0 left-0 right-0 flex justify-around bg-gray-900/80 text-white z-50 pointer-events-auto py-2">
       {buttons.map((btn) => (
         <button
           key={btn.id}
-          className="flex-1 py-2"
+          className="flex flex-col items-center w-full" 
           onClick={() => stateManager.goTo(btn.id)}
         >
-          {btn.label}
+          <img src={btn.icon} className="w-6 h-6 mb-1" />
+          <span className="text-xs">{btn.label}</span>
         </button>
       ))}
-    </div>
+    </nav>
   );
 };

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -11,10 +11,19 @@ export const CurrencyHUD = () => {
   }, []);
 
   return (
-    <div className="absolute top-0 left-0 right-0 flex justify-around text-white text-sm pointer-events-auto">
-      <span>Dust: {res.dust}</span>
-      <span>Cores: {res.cores}</span>
-      <span>Magmaton: {res.magmaton}</span>
+    <div className="absolute top-0 left-0 right-0 flex justify-between px-4 py-2 bg-black/60 text-white text-lg pointer-events-auto">
+      <div className="flex items-center gap-x-1">
+        <img src="/assets/ui/icon-dust.svg" className="w-6 h-6" />
+        <span>{res.dust}</span>
+      </div>
+      <div className="flex items-center gap-x-1">
+        <img src="/assets/ui/icon-core.svg" className="w-6 h-6" />
+        <span>{res.cores}</span>
+      </div>
+      <div className="flex items-center gap-x-1">
+        <img src="/assets/ui/icon-magmaton.svg" className="w-6 h-6" />
+        <span>{res.magmaton}</span>
+      </div>
     </div>
   );
 };

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -6,42 +6,59 @@ const screens = ['MainScreen', 'GalaxyMap', 'Profile', 'Store', 'Earn', 'Friends
 
 export const DevPanel = () => {
   if (isProd) return null;
+  const [open, setOpen] = React.useState(false);
   return (
-    <div className="fixed bottom-0 right-0 z-[400] p-2 pointer-events-auto">
-      <div className="bg-gray-800 text-white p-2 rounded flex flex-col space-y-1">
-        <button
-          className="bg-blue-500 px-2 py-1"
-          onClick={() => store.addDust(100, 'dev')}
+    <>
+      <button
+        className="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto"
+        onClick={() => setOpen(true)}
+      >
+        Dev
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-[400] bg-black/50 flex items-center justify-center"
+          onClick={() => setOpen(false)}
         >
-          Add Dust
-        </button>
-        <button
-          className="bg-blue-500 px-2 py-1"
-          onClick={() => store.resetPlanet()}
-        >
-          Reset HP
-        </button>
-        <button
-          className="bg-blue-500 px-2 py-1"
-          onClick={() => {
-            store.addCore(1, 'dev');
-            store.resetPlanet();
-          }}
-        >
-          Instant Dispatch
-        </button>
-        <div className="flex flex-wrap space-x-1 mt-2">
-          {screens.map((s) => (
+          <div
+            className="bg-gray-800 text-white p-4 rounded-lg drop-shadow pointer-events-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
             <button
-              key={s}
-              className="bg-purple-600 px-2 py-1 mt-1"
-              onClick={() => stateManager.goTo(s)}
+              className="bg-blue-500 px-2 py-1"
+              onClick={() => store.addDust(100, 'dev')}
             >
-              {s}
+              Add Dust
             </button>
-          ))}
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => store.resetPlanet()}
+            >
+              Reset HP
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => {
+                store.addCore(1, 'dev');
+                store.resetPlanet();
+              }}
+            >
+              Instant Dispatch
+            </button>
+            <div className="flex flex-wrap space-x-1 mt-2">
+              {screens.map((s) => (
+                <button
+                  key={s}
+                  className="bg-purple-600 px-2 py-1 mt-1"
+                  onClick={() => stateManager.goTo(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 };

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -18,11 +18,11 @@ export const WeaponPanel = () => {
   }, []);
 
   return (
-    <div className="absolute bottom-0 left-0 right-0 flex flex-col items-center space-y-2 pb-4 pointer-events-auto">
-      <div className="text-white text-sm">Ammo: {ammo}</div>
+    <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-2 pb-4 pointer-events-auto">
+      <div className="text-white text-base">Ammo: {ammo}</div>
       {!planet.destroyed && (
         <button
-          className="bg-blue-600 text-white px-4 py-2 rounded"
+          className="bg-blue-600 text-white px-6 py-3 rounded text-lg w-40 h-12"
           onClick={() => {
             weaponSystem.fire();
             setAmmo(weaponSystem.weapon.ammo);
@@ -33,7 +33,7 @@ export const WeaponPanel = () => {
       )}
       {planet.coreExtractable && (
         <button
-          className="bg-green-600 text-white px-4 py-2 rounded"
+          className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"
           onClick={() => {
             store.addCore(1, 'dispatch');
             store.resetPlanet();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        mobile360: '360px',
+        mobile414: '414px',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add mobile wrapper to keep fixed portrait aspect
- create currency, navbar and devpanel icons
- rebuild UI components for mobile: CurrencyHUD, WeaponPanel, BottomNavBar, DevPanel
- tweak Tailwind config with custom mobile breakpoints

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863ff21174c83228b5ebf17b76c9579