### PR TITLE
Enable tap attack on planet

### DIFF
--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { store } from '../core/GameEngine.js';
+import { weaponSystem } from '../core/WeaponSystem.js';
 
 export class MainScreen extends PIXI.Container {
   constructor(app) {
@@ -29,6 +30,12 @@ export class MainScreen extends PIXI.Container {
     this.nameLabel.anchor.set(0.5);
     this.nameLabel.y = -110;
     this.planetContainer.addChild(this.nameLabel);
+
+    this.planetContainer.eventMode = 'static';
+    this.planetContainer.cursor = 'pointer';
+    this.planetContainer.on('pointertap', () => {
+      weaponSystem.fire();
+    });
 
     this.updateView(store.get());
     this.listener = (state) => this.updateView(state);

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -10,7 +10,7 @@ export const DevPanel = () => {
   return (
     <>
       <button
-        className="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto"
+        className="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto opacity-0"
         onClick={() => setOpen(true)}
       >
         Dev

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -20,17 +20,6 @@ export const WeaponPanel = () => {
   return (
     <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-2 pb-4 pointer-events-auto">
       <div className="text-white text-base">Ammo: {ammo}</div>
-      {!planet.destroyed && (
-        <button
-          className="bg-blue-600 text-white px-6 py-3 rounded text-lg w-40 h-12"
-          onClick={() => {
-            weaponSystem.fire();
-            setAmmo(weaponSystem.weapon.ammo);
-          }}
-        >
-          Attack
-        </button>
-      )}
       {planet.coreExtractable && (
         <button
           className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"


### PR DESCRIPTION
## Summary
- fire weapon by tapping on the planet
- remove `Attack` button from weapon panel
- hide debug panel FAB button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864020781548322affd6becbdeaef98