### PR TITLE
Render canvas inside wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,16 @@
       aspect-ratio: 9 / 16;
       position: relative;
       margin: auto;
+      overflow: hidden;
       background: radial-gradient(circle at 50% 20%, #111, #000);
     }
-    #game-canvas, #ui-layer {
+    #canvas-container {
+      width: 100%;
+      height: 100%;
+      position: relative;
+    }
+    #game-canvas,
+    #ui-layer {
       position: absolute;
       inset: 0;
     }
@@ -41,7 +48,7 @@
 </head>
 <body>
   <div id="wrapper">
-    <canvas id="game-canvas"></canvas>
+    <div id="canvas-container"></div>
     <div id="ui-layer"></div>
   </div>
   <script type="module" src="/src/main.tsx"></script>

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -4,8 +4,10 @@ import { StateManager } from './StateManager.js';
 
 export const store = new GameStateStore();
 
+const wrapper = document.getElementById('wrapper');
+
 export const app = new PIXI.Application({
-  resizeTo: window,
+  resizeTo: wrapper,
   backgroundColor: 0x000000,
   antialias: true,
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,9 +9,11 @@ import { WeaponPanel } from './ui/WeaponPanel.tsx';
 import { RewardDustPopup } from './ui/RewardDustPopup.tsx';
 import { RewardCorePopup } from './ui/RewardCorePopup.tsx';
 
-const canvasElem = document.getElementById('game-canvas');
-canvasElem.replaceWith(app.view);
+const container = document.getElementById('canvas-container');
+container.appendChild(app.view);
 app.view.id = 'game-canvas';
+app.view.style.width = '100%';
+app.view.style.height = '100%';
 
 
 function UI() {

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -11,7 +11,7 @@ const buttons = [
 
 export const BottomNavBar = () => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 flex justify-around bg-gray-900/80 text-white z-50 pointer-events-auto py-2">
+    <nav className="absolute bottom-0 left-0 right-0 flex justify-around bg-gray-900/80 text-white z-50 pointer-events-auto py-2">
       {buttons.map((btn) => (
         <button
           key={btn.id}

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -10,14 +10,14 @@ export const DevPanel = () => {
   return (
     <>
       <button
-        className="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto opacity-0"
+        className="absolute bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto opacity-0"
         onClick={() => setOpen(true)}
       >
         Dev
       </button>
       {open && (
         <div
-          className="fixed inset-0 z-[400] bg-black/50 flex items-center justify-center"
+          className="absolute inset-0 z-[400] bg-black/50 flex items-center justify-center"
           onClick={() => setOpen(false)}
         >
           <div


### PR DESCRIPTION
## Summary
- contain Pixi canvas within the new `canvas-container`
- ensure wrapper has overflow hidden
- mount Pixi app view inside `canvas-container`
- resize Pixi app to wrapper element
- anchor UI elements to wrapper instead of viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864041eb7a08322a0c07b7733b60742