### PR TITLE
Revamp MainScreen mobile layout

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -4,6 +4,8 @@
     "iconDust": "ui/icon-dust.svg",
     "iconCore": "ui/icon-core.svg",
     "iconMagmaton": "ui/icon-magmaton.svg",
+    "iconAmmo": "ui/icon-ammo.svg",
+    "bgStars": "ui/bg-stars.svg",
     "navProfile": "ui/nav-profile.svg",
     "navStore": "ui/nav-store.svg",
     "navMain": "ui/nav-main.svg",

--- a/assets/ui/bg-stars.svg
+++ b/assets/ui/bg-stars.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#0a0a2a"/>
+  <circle cx="32" cy="16" r="2" fill="white"/>
+  <circle cx="12" cy="42" r="1.5" fill="white"/>
+  <circle cx="50" cy="50" r="1" fill="white"/>
+</svg>

--- a/assets/ui/icon-ammo.svg
+++ b/assets/ui/icon-ammo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect x="28" y="8" width="8" height="48" fill="gray"/>
+  <rect x="24" y="8" width="16" height="10" fill="silver"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -28,12 +28,18 @@
       position: relative;
       margin: auto;
       overflow: hidden;
-      background: radial-gradient(circle at 50% 20%, #111, #000);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      background: url('/assets/ui/bg-stars.svg') center/cover,
+        linear-gradient(180deg, #050d2a, #000);
     }
     #canvas-container {
       width: 100%;
       height: 100%;
       position: relative;
+      flex: 1 1 auto;
     }
     #game-canvas,
     #ui-layer {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,7 +32,7 @@ function UI() {
   }, []);
 
   return (
-    <div className="absolute inset-0 flex flex-col justify-end pointer-events-none">
+    <div className="absolute inset-0 flex flex-col justify-between items-center pointer-events-none">
       <CurrencyHUD />
       <WeaponPanel />
       {dustReward !== null && (

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -8,10 +8,14 @@ export class MainScreen extends PIXI.Container {
     this.screenId = 'MainScreen';
 
     const { width, height } = app.renderer;
+    this.radius = Math.max(width * 0.28, 114);
 
     this.planetContainer = new PIXI.Container();
     this.planetContainer.x = width / 2;
-    this.planetContainer.y = height * 0.4;
+    this.planetContainer.y = height / 2;
+    this.planetContainer.alpha = 0;
+    this.planetContainer.scale.set(0.8);
+    PIXI.Ticker.shared.add(this.animateIn, this);
     this.addChild(this.planetContainer);
 
     this.planetGraphic = new PIXI.Graphics();
@@ -19,16 +23,16 @@ export class MainScreen extends PIXI.Container {
 
     this.hpBg = new PIXI.Graphics();
     this.hpBg.beginFill(0x333333);
-    this.hpBg.drawRect(-80, -90, 160, 10);
+    this.hpBg.drawRect(-this.radius, -this.radius - 20, this.radius * 2, 12);
     this.hpBg.endFill();
     this.planetContainer.addChild(this.hpBg);
 
     this.hpBar = new PIXI.Graphics();
     this.planetContainer.addChild(this.hpBar);
 
-    this.nameLabel = new PIXI.Text('', { fill: 'white', fontSize: 14 });
+    this.nameLabel = new PIXI.Text('', { fill: 'white', fontSize: 20 });
     this.nameLabel.anchor.set(0.5);
-    this.nameLabel.y = -110;
+    this.nameLabel.y = -this.radius - 40;
     this.planetContainer.addChild(this.nameLabel);
 
     this.planetContainer.eventMode = 'static';
@@ -46,13 +50,13 @@ export class MainScreen extends PIXI.Container {
     const p = state.planet;
     this.planetGraphic.clear();
     this.planetGraphic.beginFill(p.destroyed ? 0x555555 : 0x8888ff);
-    this.planetGraphic.drawCircle(0, 0, 70);
+    this.planetGraphic.drawCircle(0, 0, this.radius);
     this.planetGraphic.endFill();
 
     const ratio = p.hp / p.maxHp;
     this.hpBar.clear();
     this.hpBar.beginFill(0xff4444);
-    this.hpBar.drawRect(-80, -90, 160 * ratio, 10);
+    this.hpBar.drawRect(-this.radius, -this.radius - 20, this.radius * 2 * ratio, 12);
     this.hpBar.endFill();
 
     this.nameLabel.text = p.name;
@@ -61,5 +65,17 @@ export class MainScreen extends PIXI.Container {
   destroy(opts) {
     store.off('update', this.listener);
     super.destroy(opts);
+  }
+
+  animateIn(delta) {
+    const s = this.planetContainer.scale.x + 0.05 * delta;
+    if (s >= 1) {
+      this.planetContainer.scale.set(1);
+      this.planetContainer.alpha = 1;
+      PIXI.Ticker.shared.remove(this.animateIn, this);
+    } else {
+      this.planetContainer.scale.set(s);
+      this.planetContainer.alpha = s;
+    }
   }
 }

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -11,14 +11,17 @@ const buttons = [
 
 export const BottomNavBar = () => {
   return (
-    <nav className="absolute bottom-0 left-0 right-0 flex justify-around bg-gray-900/80 text-white z-50 pointer-events-auto py-2">
+    <nav className="absolute bottom-0 left-0 right-0 flex justify-between bg-gray-900/80 text-white z-50 pointer-events-auto h-14 px-2">
       {buttons.map((btn) => (
         <button
           key={btn.id}
-          className="flex flex-col items-center w-full" 
+          className={`flex flex-col items-center flex-1 ${btn.id === 'MainScreen' ? 'scale-110' : ''}`}
           onClick={() => stateManager.goTo(btn.id)}
         >
-          <img src={btn.icon} className="w-6 h-6 mb-1" />
+          <img
+            src={btn.icon}
+            className={`${btn.id === 'MainScreen' ? 'w-10 h-10' : 'w-8 h-8'} mb-1`}
+          />
           <span className="text-xs">{btn.label}</span>
         </button>
       ))}

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -11,18 +11,18 @@ export const CurrencyHUD = () => {
   }, []);
 
   return (
-    <div className="absolute top-0 left-0 right-0 flex justify-between px-4 py-2 bg-black/60 text-white text-lg pointer-events-auto">
-      <div className="flex items-center gap-x-1">
-        <img src="/assets/ui/icon-dust.svg" className="w-6 h-6" />
-        <span>{res.dust}</span>
+    <div className="absolute top-0 left-0 right-0 flex justify-center gap-6 px-4 py-3 bg-black/60 text-white pointer-events-auto items-center rounded-b animate-fadeIn">
+      <div className="flex items-center gap-x-2">
+        <img src="/assets/ui/icon-dust.svg" className="w-8 h-8" />
+        <span className="text-base">{res.dust}</span>
       </div>
-      <div className="flex items-center gap-x-1">
-        <img src="/assets/ui/icon-core.svg" className="w-6 h-6" />
-        <span>{res.cores}</span>
+      <div className="flex items-center gap-x-2">
+        <img src="/assets/ui/icon-core.svg" className="w-8 h-8" />
+        <span className="text-base">{res.cores}</span>
       </div>
-      <div className="flex items-center gap-x-1">
-        <img src="/assets/ui/icon-magmaton.svg" className="w-6 h-6" />
-        <span>{res.magmaton}</span>
+      <div className="flex items-center gap-x-2">
+        <img src="/assets/ui/icon-magmaton.svg" className="w-8 h-8" />
+        <span className="text-base">{res.magmaton}</span>
       </div>
     </div>
   );

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -18,8 +18,11 @@ export const WeaponPanel = () => {
   }, []);
 
   return (
-    <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-2 pb-4 pointer-events-auto">
-      <div className="text-white text-base">Ammo: {ammo}</div>
+    <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-4 pb-6 pointer-events-auto animate-fadeIn">
+      <div className="flex items-center gap-x-2 bg-black/60 px-3 py-1 rounded">
+        <img src="/assets/ui/icon-ammo.svg" className="w-6 h-6" />
+        <span className="text-white text-lg">{ammo}</span>
+      </div>
       {planet.coreExtractable && (
         <button
           className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,15 @@ export default {
         mobile360: '360px',
         mobile414: '414px',
       },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0', transform: 'scale(0.9)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
+        },
+      },
+      animation: {
+        fadeIn: 'fadeIn 0.4s ease-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- style MainScreen with a larger planet and fade-in animation
- improve HUD sizing and spacing
- overhaul ammo panel and bottom navbar
- add background stars and ammo icon placeholders
- define fade-in animation in Tailwind config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686406fa5b808322b83176f7150d635f