### PR TITLE
Improve mobile HUD and interactions

### DIFF
--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -18,6 +18,13 @@ export class MainScreen extends PIXI.Container {
     PIXI.Ticker.shared.add(this.animateIn, this);
     this.addChild(this.planetContainer);
 
+    this.glow = new PIXI.Graphics();
+    this.glow.beginFill(0x6666ff, 0.4);
+    this.glow.drawCircle(0, 0, this.radius + 10);
+    this.glow.endFill();
+    this.glow.filters = [new PIXI.filters.BlurFilter(8)];
+    this.planetContainer.addChild(this.glow);
+
     this.planetGraphic = new PIXI.Graphics();
     this.planetContainer.addChild(this.planetGraphic);
 
@@ -39,6 +46,7 @@ export class MainScreen extends PIXI.Container {
     this.planetContainer.cursor = 'pointer';
     this.planetContainer.on('pointertap', () => {
       weaponSystem.fire();
+      this.bump();
     });
 
     this.updateView(store.get());
@@ -52,6 +60,10 @@ export class MainScreen extends PIXI.Container {
     this.planetGraphic.beginFill(p.destroyed ? 0x555555 : 0x8888ff);
     this.planetGraphic.drawCircle(0, 0, this.radius);
     this.planetGraphic.endFill();
+    this.glow.clear();
+    this.glow.beginFill(p.destroyed ? 0x444444 : 0x6666ff, 0.4);
+    this.glow.drawCircle(0, 0, this.radius + 10);
+    this.glow.endFill();
 
     const ratio = p.hp / p.maxHp;
     this.hpBar.clear();
@@ -76,6 +88,21 @@ export class MainScreen extends PIXI.Container {
     } else {
       this.planetContainer.scale.set(s);
       this.planetContainer.alpha = s;
+    }
+  }
+
+  bump() {
+    this.planetContainer.scale.set(1.1);
+    PIXI.Ticker.shared.add(this.restoreScale, this);
+  }
+
+  restoreScale(delta) {
+    const s = this.planetContainer.scale.x - 0.1 * delta;
+    if (s <= 1) {
+      this.planetContainer.scale.set(1);
+      PIXI.Ticker.shared.remove(this.restoreScale, this);
+    } else {
+      this.planetContainer.scale.set(s);
     }
   }
 }

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { stateManager } from '../core/GameEngine.js';
+import React, { useEffect, useState } from 'react';
+import { stateManager, store } from '../core/GameEngine.js';
 
 const buttons = [
   { id: 'Profile', label: 'Profile', icon: '/assets/ui/nav-profile.svg' },
@@ -10,21 +10,32 @@ const buttons = [
 ];
 
 export const BottomNavBar = () => {
+  const [active, setActive] = useState(store.get().currentScreen);
+
+  useEffect(() => {
+    const cb = (s: any) => setActive(s.currentScreen);
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
   return (
-    <nav className="absolute bottom-0 left-0 right-0 flex justify-between bg-gray-900/80 text-white z-50 pointer-events-auto h-14 px-2">
-      {buttons.map((btn) => (
-        <button
-          key={btn.id}
-          className={`flex flex-col items-center flex-1 ${btn.id === 'MainScreen' ? 'scale-110' : ''}`}
-          onClick={() => stateManager.goTo(btn.id)}
-        >
-          <img
-            src={btn.icon}
-            className={`${btn.id === 'MainScreen' ? 'w-10 h-10' : 'w-8 h-8'} mb-1`}
-          />
-          <span className="text-xs">{btn.label}</span>
-        </button>
-      ))}
+    <nav className="absolute bottom-0 left-0 right-0 flex justify-between bg-slate-800/70 border-t border-slate-700 text-white z-50 pointer-events-auto h-14 px-2 animate-fadeIn">
+      {buttons.map((btn) => {
+        const isActive = btn.id === active;
+        return (
+          <button
+            key={btn.id}
+            className={`flex flex-col items-center flex-1 transition-transform ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
+            onClick={() => stateManager.goTo(btn.id)}
+          >
+            <img
+              src={btn.icon}
+              className={`${isActive ? 'w-10 h-10' : 'w-8 h-8'} mb-1`}
+            />
+            <span className="text-xs">{btn.label}</span>
+          </button>
+        );
+      })}
     </nav>
   );
 };

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -11,18 +11,18 @@ export const CurrencyHUD = () => {
   }, []);
 
   return (
-    <div className="absolute top-0 left-0 right-0 flex justify-center gap-6 px-4 py-3 bg-black/60 text-white pointer-events-auto items-center rounded-b animate-fadeIn">
+    <div className="absolute top-0 left-0 right-0 flex justify-center gap-6 px-4 py-3 bg-slate-800/70 border border-slate-700 rounded-b pointer-events-auto items-center animate-fadeIn">
       <div className="flex items-center gap-x-2">
         <img src="/assets/ui/icon-dust.svg" className="w-8 h-8" />
-        <span className="text-base">{res.dust}</span>
+        <span className="text-lg text-white">{res.dust}</span>
       </div>
       <div className="flex items-center gap-x-2">
         <img src="/assets/ui/icon-core.svg" className="w-8 h-8" />
-        <span className="text-base">{res.cores}</span>
+        <span className="text-lg text-white">{res.cores}</span>
       </div>
       <div className="flex items-center gap-x-2">
         <img src="/assets/ui/icon-magmaton.svg" className="w-8 h-8" />
-        <span className="text-base">{res.magmaton}</span>
+        <span className="text-lg text-white">{res.magmaton}</span>
       </div>
     </div>
   );

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -19,9 +19,9 @@ export const WeaponPanel = () => {
 
   return (
     <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-4 pb-6 pointer-events-auto animate-fadeIn">
-      <div className="flex items-center gap-x-2 bg-black/60 px-3 py-1 rounded">
+      <div className="flex items-center gap-x-2 bg-slate-800/70 border border-slate-700 rounded px-4 py-2">
         <img src="/assets/ui/icon-ammo.svg" className="w-6 h-6" />
-        <span className="text-white text-lg">{ammo}</span>
+        <span className="text-lg text-white">{ammo}</span>
       </div>
       {planet.coreExtractable && (
         <button


### PR DESCRIPTION
## Summary
- tweak currency bar styling
- improve ammo panel appearance
- highlight active navbar tab based on GameStateStore
- add glow and tap animation to MainScreen planet

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68640b66cef08322adfbbea4b84a1e97