### PR TITLE
Finalize mobile layout and HUD polish

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -5,11 +5,13 @@
     "iconCore": "ui/icon-core.svg",
     "iconMagmaton": "ui/icon-magmaton.svg",
     "iconAmmo": "ui/icon-ammo.svg",
-    "bgStars": "ui/bg-stars.svg",
+    "bgStars": "ui/bg_stars.svg",
     "navProfile": "ui/nav-profile.svg",
     "navStore": "ui/nav-store.svg",
     "navMain": "ui/nav-main.svg",
     "navEarn": "ui/nav-earn.svg",
-    "navFriends": "ui/nav-friends.svg"
+    "navFriends": "ui/nav-friends.svg",
+    "weaponPlaceholder": "ui/weapon_placeholder.svg",
+    "iconDev": "ui/icon-dev.svg"
   }
 }

--- a/assets/ui/bg_stars.svg
+++ b/assets/ui/bg_stars.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="none"/>
+  <circle cx="10" cy="10" r="1" fill="white"/>
+  <circle cx="30" cy="40" r="1" fill="white"/>
+  <circle cx="70" cy="20" r="1" fill="white"/>
+  <circle cx="90" cy="80" r="1" fill="white"/>
+</svg>

--- a/assets/ui/icon-dev.svg
+++ b/assets/ui/icon-dev.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#a855f7" />
+  <text x="24" y="30" font-size="20" text-anchor="middle" fill="#fff">DEV</text>
+</svg>

--- a/assets/ui/weapon_placeholder.svg
+++ b/assets/ui/weapon_placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="28" width="48" height="8" fill="#777" />
+  <rect x="28" y="16" width="8" height="32" fill="#aaa" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
       flex-direction: column;
       justify-content: space-between;
       align-items: center;
-      background: url('/assets/ui/bg-stars.svg') center/cover,
-        linear-gradient(180deg, #050d2a, #000);
+      background: url('/assets/ui/bg_stars.svg') center/cover,
+        linear-gradient(180deg, #0d1d2d, #261345);
     }
     #canvas-container {
       width: 100%;

--- a/src/core/WeaponSystem.js
+++ b/src/core/WeaponSystem.js
@@ -2,11 +2,19 @@ import { store } from './GameEngine.js';
 
 class WeaponSystem {
   constructor() {
-    this.weapon = {
-      damage: 10,
-      ammo: 10,
-      ammoMax: 10,
-    };
+    this.weapons = [
+      { id: 'blaster', name: 'Blaster', damage: 10, ammo: 10, ammoMax: 10 },
+      { id: 'laser', name: 'Laser', damage: 20, ammo: 5, ammoMax: 5 },
+    ];
+    this.weapon = this.weapons[0];
+  }
+
+  selectWeapon(id) {
+    const w = this.weapons.find((wp) => wp.id === id);
+    if (w) {
+      this.weapon = w;
+      store.emit('update', store.state);
+    }
   }
 
   fire() {

--- a/src/screens/Earn.js
+++ b/src/screens/Earn.js
@@ -10,13 +10,5 @@ export class Earn extends PIXI.Container {
     label.y = app.renderer.height / 2;
     this.addChild(label);
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
   }
 }

--- a/src/screens/Friends.js
+++ b/src/screens/Friends.js
@@ -10,13 +10,5 @@ export class Friends extends PIXI.Container {
     label.y = app.renderer.height / 2;
     this.addChild(label);
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
   }
 }

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -20,22 +20,28 @@ export class MainScreen extends PIXI.Container {
 
     this.glow = new PIXI.Graphics();
     this.glow.beginFill(0x6666ff, 0.4);
-    this.glow.drawCircle(0, 0, this.radius + 10);
+    this.glow.drawCircle(0, 0, this.radius * 1.5);
     this.glow.endFill();
-    this.glow.filters = [new PIXI.filters.BlurFilter(8)];
+    this.glow.filters = [new PIXI.filters.BlurFilter(12)];
     this.planetContainer.addChild(this.glow);
 
     this.planetGraphic = new PIXI.Graphics();
     this.planetContainer.addChild(this.planetGraphic);
 
     this.hpBg = new PIXI.Graphics();
-    this.hpBg.beginFill(0x333333);
-    this.hpBg.drawRect(-this.radius, -this.radius - 20, this.radius * 2, 12);
+    this.hpBg.beginFill(0x222222, 0.8);
+    this.hpBg.lineStyle(2, 0xffffff);
+    this.hpBg.drawRoundedRect(-this.radius, -this.radius - 24, this.radius * 2, 16, 8);
     this.hpBg.endFill();
     this.planetContainer.addChild(this.hpBg);
 
     this.hpBar = new PIXI.Graphics();
     this.planetContainer.addChild(this.hpBar);
+
+    this.hpText = new PIXI.Text('', { fill: 'white', fontSize: 16 });
+    this.hpText.anchor.set(0.5);
+    this.hpText.y = -this.radius - 16;
+    this.planetContainer.addChild(this.hpText);
 
     this.nameLabel = new PIXI.Text('', { fill: 'white', fontSize: 20 });
     this.nameLabel.anchor.set(0.5);
@@ -62,14 +68,15 @@ export class MainScreen extends PIXI.Container {
     this.planetGraphic.endFill();
     this.glow.clear();
     this.glow.beginFill(p.destroyed ? 0x444444 : 0x6666ff, 0.4);
-    this.glow.drawCircle(0, 0, this.radius + 10);
+    this.glow.drawCircle(0, 0, this.radius * 1.5);
     this.glow.endFill();
 
     const ratio = p.hp / p.maxHp;
     this.hpBar.clear();
     this.hpBar.beginFill(0xff4444);
-    this.hpBar.drawRect(-this.radius, -this.radius - 20, this.radius * 2 * ratio, 12);
+    this.hpBar.drawRoundedRect(-this.radius, -this.radius - 24, this.radius * 2 * ratio, 16, 8);
     this.hpBar.endFill();
+    this.hpText.text = `${p.hp}/${p.maxHp}`;
 
     this.nameLabel.text = p.name;
   }

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -10,13 +10,5 @@ export class Profile extends PIXI.Container {
     label.y = app.renderer.height / 2;
     this.addChild(label);
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
   }
 }

--- a/src/screens/Store.js
+++ b/src/screens/Store.js
@@ -10,13 +10,5 @@ export class Store extends PIXI.Container {
     label.y = app.renderer.height / 2;
     this.addChild(label);
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
   }
 }

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -25,12 +25,12 @@ export const BottomNavBar = () => {
         return (
           <button
             key={btn.id}
-            className={`flex flex-col items-center flex-1 transition-transform ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
+            className={`flex flex-col items-center flex-1 transition-transform min-w-[56px] py-1 ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
             onClick={() => stateManager.goTo(btn.id)}
           >
             <img
               src={btn.icon}
-              className={`${isActive ? 'w-10 h-10' : 'w-8 h-8'} mb-1`}
+              className={`${isActive ? 'w-10 h-10' : 'w-8 h-8'} mb-1 transition-transform`}
             />
             <span className="text-xs">{btn.label}</span>
           </button>

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { store } from '../core/GameEngine.js';
+import { store, stateManager } from '../core/GameEngine.js';
 
 export const CurrencyHUD = () => {
   const [res, setRes] = useState(store.get().resources);
@@ -11,18 +11,21 @@ export const CurrencyHUD = () => {
   }, []);
 
   return (
-    <div className="absolute top-0 left-0 right-0 flex justify-center gap-6 px-4 py-3 bg-slate-800/70 border border-slate-700 rounded-b pointer-events-auto items-center animate-fadeIn">
+    <div
+      className="absolute top-0 left-0 right-0 flex justify-center gap-4 px-4 py-3 bg-slate-800/70 border-b border-slate-700 pointer-events-auto items-center animate-fadeIn"
+      onClick={() => stateManager.goTo('Store')}
+    >
       <div className="flex items-center gap-x-2">
-        <img src="/assets/ui/icon-dust.svg" className="w-8 h-8" />
-        <span className="text-lg text-white">{res.dust}</span>
+        <img src="/assets/ui/icon-dust.svg" className="w-6 h-6" />
+        <span className="text-base text-yellow-300 font-medium">{res.dust}</span>
       </div>
       <div className="flex items-center gap-x-2">
-        <img src="/assets/ui/icon-core.svg" className="w-8 h-8" />
-        <span className="text-lg text-white">{res.cores}</span>
+        <img src="/assets/ui/icon-core.svg" className="w-6 h-6" />
+        <span className="text-base text-blue-300 font-medium">{res.cores}</span>
       </div>
       <div className="flex items-center gap-x-2">
-        <img src="/assets/ui/icon-magmaton.svg" className="w-8 h-8" />
-        <span className="text-lg text-white">{res.magmaton}</span>
+        <img src="/assets/ui/icon-magmaton.svg" className="w-6 h-6" />
+        <span className="text-base text-violet-300 font-medium">{res.magmaton}</span>
       </div>
     </div>
   );

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -10,10 +10,10 @@ export const DevPanel = () => {
   return (
     <>
       <button
-        className="absolute bottom-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto opacity-0"
+        className="absolute top-4 right-4 w-12 h-12 rounded-full bg-purple-600 text-white z-[400] pointer-events-auto"
         onClick={() => setOpen(true)}
       >
-        Dev
+        <img src="/assets/ui/icon-dev.svg" className="w-full h-full" />
       </button>
       {open && (
         <div
@@ -24,6 +24,7 @@ export const DevPanel = () => {
             className="bg-gray-800 text-white p-4 rounded-lg drop-shadow pointer-events-auto"
             onClick={(e) => e.stopPropagation()}
           >
+            <button className="absolute top-2 right-2" onClick={() => setOpen(false)}>✕</button>
             <button
               className="bg-blue-500 px-2 py-1"
               onClick={() => store.addDust(100, 'dev')}

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -5,23 +5,52 @@ import { store } from '../core/GameEngine.js';
 export const WeaponPanel = () => {
   const [ammo, setAmmo] = useState(weaponSystem.weapon.ammo);
   const [planet, setPlanet] = useState(store.get().planet);
+  const [screen, setScreen] = useState(store.get().currentScreen);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const upd = () => setAmmo(weaponSystem.weapon.ammo);
     const planetCb = (s: any) => setPlanet({ ...s.planet });
+    const scr = (s: any) => setScreen(s.currentScreen);
     store.on('update', planetCb);
     store.on('update', upd);
+    store.on('update', scr);
     return () => {
       store.off('update', planetCb);
       store.off('update', upd);
+      store.off('update', scr);
     };
   }, []);
 
+  if (screen !== 'MainScreen') return null;
+
   return (
     <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-4 pb-6 pointer-events-auto animate-fadeIn">
-      <div className="flex items-center gap-x-2 bg-slate-800/70 border border-slate-700 rounded px-4 py-2">
-        <img src="/assets/ui/icon-ammo.svg" className="w-6 h-6" />
-        <span className="text-lg text-white">{ammo}</span>
+      <div className="relative">
+        <button
+          className="flex items-center gap-x-2 bg-slate-800/70 border border-slate-700 rounded px-4 py-2"
+          onClick={() => setOpen(!open)}
+        >
+          <img src="/assets/ui/weapon_placeholder.svg" className="w-6 h-6" />
+          <span className="text-lg text-white">{ammo}</span>
+        </button>
+        {open && (
+          <div className="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 bg-slate-800/90 border border-slate-700 rounded shadow-lg">
+            {weaponSystem.weapons.map((w) => (
+              <button
+                key={w.id}
+                className="flex items-center gap-x-2 px-3 py-1 text-white w-full text-left hover:bg-slate-700"
+                onClick={() => {
+                  weaponSystem.selectWeapon(w.id);
+                  setOpen(false);
+                }}
+              >
+                <img src="/assets/ui/weapon_placeholder.svg" className="w-5 h-5" />
+                <span className="text-sm">{w.ammo}</span>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
       {planet.coreExtractable && (
         <button


### PR DESCRIPTION
## Summary
- add SVG placeholders for background, dev icon and weapon
- refine gradient background and assets manifest
- improve planet glow and HP bar styling
- implement weapon selector dropdown and visibility on MainScreen only
- style currency HUD and nav buttons for mobile UX
- reposition DevPanel trigger and add close button
- remove back buttons from root screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68640eebbae483229fe3480b3259aab7