### PR TITLE
Add animated planet destruction effects

### DIFF
--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -10,6 +10,7 @@ export class GameStateStore {
         maxHp: 100,
         destroyed: false,
         coreExtractable: false,
+        dustSinceSpawn: 0,
       },
       resources: {
         dust: 0,
@@ -46,7 +47,11 @@ export class GameStateStore {
 
   addDust(amount, source = 'attack') {
     this.state.resources.dust += amount;
-    this.emit('reward:dust', { amount, source });
+    if (source === 'attack') {
+      this.state.planet.dustSinceSpawn += amount;
+    } else {
+      this.emit('reward:dust', { amount, source });
+    }
     this.emit('update', this.state);
   }
 
@@ -64,6 +69,13 @@ export class GameStateStore {
       p.hp = 0;
       p.destroyed = true;
       p.coreExtractable = true;
+      if (p.dustSinceSpawn > 0) {
+        this.emit('reward:dust', {
+          amount: p.dustSinceSpawn,
+          source: 'planet_destroy',
+        });
+        p.dustSinceSpawn = 0;
+      }
     }
     this.emit('update', this.state);
   }
@@ -73,6 +85,7 @@ export class GameStateStore {
     p.hp = p.maxHp;
     p.destroyed = false;
     p.coreExtractable = false;
+    p.dustSinceSpawn = 0;
     this.emit('update', this.state);
   }
 }

--- a/src/core/WeaponSystem.js
+++ b/src/core/WeaponSystem.js
@@ -18,12 +18,16 @@ class WeaponSystem {
   }
 
   fire() {
-    if (this.weapon.ammo <= 0) return false;
-    if (store.state.planet.destroyed) return false;
+    if (this.weapon.ammo <= 0) return 0;
+    if (store.state.planet.destroyed) return 0;
     this.weapon.ammo -= 1;
-    store.damagePlanet(this.weapon.damage);
+    store.emit('update', store.state);
+    return this.weapon.damage;
+  }
+
+  applyHit(damage) {
+    store.damagePlanet(damage);
     store.addDust(1, 'attack');
-    return true;
   }
 
   addAmmo(amount) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,9 @@ function UI() {
   const [coreReward, setCoreReward] = React.useState<number | null>(null);
 
   React.useEffect(() => {
-    const dustCb = ({ amount }: any) => setDustReward(amount);
+    const dustCb = ({ amount, source }: any) => {
+      if (source !== 'attack') setDustReward(amount);
+    };
     const coreCb = ({ amount }: any) => setCoreReward(amount);
     store.on('reward:dust', dustCb);
     store.on('reward:core', coreCb);

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { isProd } from '../data/BuildFlags.js';
 import { stateManager, store } from '../core/GameEngine.js';
+import { weaponSystem } from '../core/WeaponSystem.js';
 
 const screens = ['MainScreen', 'GalaxyMap', 'Profile', 'Store', 'Earn', 'Friends'];
 
@@ -36,6 +37,18 @@ export const DevPanel = () => {
               onClick={() => store.resetPlanet()}
             >
               Reset HP
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => weaponSystem.addAmmo(10)}
+            >
+              Add ammo
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => store.damagePlanet(store.state.planet.hp)}
+            >
+              Destroy planet
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"


### PR DESCRIPTION
## Summary
- add `dustSinceSpawn` and reward emission on planet destroy
- refactor weapon firing to delay damage until projectile hit
- show dust popup only when source isn't `attack`
- overhaul MainScreen with projectiles, pulsing glow, voxel mask and planet core
- expand DevPanel with `Add ammo` and `Destroy planet` actions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68641539d8ec8322b287b05c0e5876c8