### PR TITLE
Improve planet mask safety

### DIFF
--- a/src/core/PlanetMask.js
+++ b/src/core/PlanetMask.js
@@ -15,9 +15,19 @@ export class PlanetMask {
     this.sprite.visible = false;
     this.totalArea = Math.PI * radius * radius;
     this.removedArea = 0;
+    this.destroyed = false;
+  }
+
+  isValid() {
+    return (
+      this.texture instanceof PIXI.Texture &&
+      !this.texture.destroyed &&
+      !this.destroyed
+    );
   }
 
   reset() {
+    if (!this.isValid()) return;
     const size = this.canvas.width;
     this.ctx.globalCompositeOperation = 'source-over';
     this.ctx.clearRect(0, 0, size, size);
@@ -28,6 +38,7 @@ export class PlanetMask {
   }
 
   cut(x, y, r, brush = 'circle') {
+    if (!this.isValid()) return;
     this.ctx.save();
     this.ctx.globalCompositeOperation = 'destination-out';
     this.drawBrush(brush, x + this.radius, y + this.radius, r);
@@ -64,5 +75,16 @@ export class PlanetMask {
 
   coverage() {
     return this.removedArea / this.totalArea;
+  }
+
+  destroy(opts) {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.sprite?.destroy(opts);
+    if (this.texture && !this.texture.destroyed) {
+      this.texture.destroy(true);
+    }
+    this.canvas = null;
+    this.ctx = null;
   }
 }

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -47,9 +47,16 @@ export const DevPanel = () => {
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"
-              onClick={() => store.damagePlanet(store.state.planet.hp)}
+              onClick={() => {
+                const scr: any = stateManager.current;
+                if (scr && typeof scr.killPlanet === 'function') {
+                  scr.killPlanet();
+                } else {
+                  store.damagePlanet(store.state.planet.hp);
+                }
+              }}
             >
-              Destroy planet
+              Instant Kill
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"


### PR DESCRIPTION
## Summary
- validate mask textures and guard updates
- clean up mask when destroying MainScreen
- expose `killPlanet` API for DevPanel
- call safe kill from DevPanel

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68641ef450b48322a6c3dd1bedfa2c05