### PR TITLE
Fix PlanetMask alignment bug

### DIFF
--- a/src/core/PlanetMask.js
+++ b/src/core/PlanetMask.js
@@ -12,6 +12,8 @@ export class PlanetMask {
     this.ctx.fillRect(0, 0, size, size);
     this.texture = PIXI.Texture.from(this.canvas);
     this.sprite = new PIXI.Sprite(this.texture);
+    this.sprite.anchor.set(0.5);
+    this.sprite.position.set(0, 0);
     this.sprite.visible = false;
     this.totalArea = Math.PI * radius * radius;
     this.removedArea = 0;

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -42,6 +42,10 @@ export class MainScreen extends PIXI.Container {
     this.surface = new PIXI.Graphics();
     this.planetMask = new PlanetMask(this.radius);
     if (this.planetMask.isValid()) {
+      console.log(
+        'PlanetMask visible area',
+        this.planetMask.totalArea - this.planetMask.removedArea
+      );
       this.surface.mask = this.planetMask.sprite;
       this.planetContainer.addChild(this.planetMask.sprite);
       this.planetMask.sprite.renderable = false;


### PR DESCRIPTION
## Summary
- align planet mask sprite with planet center
- log visible area when applying mask

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68642986b1148322bfdf1138c2bfcfe5