### PR TITLE
Add dynamic oval brush and improved projectile logic

### DIFF
--- a/src/core/BrushManager.js
+++ b/src/core/BrushManager.js
@@ -1,6 +1,6 @@
 export const BrushManager = {
   brushes: ['circle', 'oval', 'star'],
-  current: 'circle',
+  current: 'oval',
   set(brush) {
     if (this.brushes.includes(brush)) this.current = brush;
   },

--- a/src/core/PlanetMask.js
+++ b/src/core/PlanetMask.js
@@ -54,7 +54,7 @@ export class PlanetMask {
     const ctx = this.ctx;
     ctx.beginPath();
     if (brush === 'oval') {
-      ctx.ellipse(cx, cy, r * 1.4, r, 0, 0, Math.PI * 2);
+      ctx.ellipse(cx, cy, r * 1.6, r, 0, 0, Math.PI * 2);
     } else if (brush === 'star') {
       const spikes = 5;
       const outerR = r;
@@ -74,6 +74,14 @@ export class PlanetMask {
       ctx.arc(cx, cy, r, 0, Math.PI * 2);
     }
     ctx.fill();
+  }
+
+  removeAll() {
+    if (!this.isValid()) return;
+    const size = this.canvas.width;
+    this.ctx.clearRect(0, 0, size, size);
+    this.texture.update();
+    this.removedArea = this.totalArea;
   }
 
   coverage() {


### PR DESCRIPTION
## Summary
- default brush is now Oval
- Oval shape uses 1.6:1 ratio
- projectiles start from the edge and land exactly where they hit
- hole size scales with damage and clamps between 6% and 45%
- InstantKill clears the mask before running reward logic

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864305f356883229b64f729c0187c47