### PR TITLE
Add Galaxy Map screen with sector unlock

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -12,6 +12,10 @@
     "navEarn": "ui/nav-earn.svg",
     "navFriends": "ui/nav-friends.svg",
     "weaponPlaceholder": "ui/weapon_placeholder.svg",
-    "iconDev": "ui/icon-dev.svg"
+    "iconDev": "ui/icon-dev.svg",
+    "iconLock": "ui/icon-lock.svg",
+    "iconPlanet": "ui/icon-planet.svg",
+    "iconNebula": "ui/icon-nebula.svg",
+    "iconColony": "ui/icon-colony.svg"
   }
 }

--- a/assets/ui/icon-colony.svg
+++ b/assets/ui/icon-colony.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <polygon points="24,6 40,18 40,30 24,42 8,30 8,18" fill="#3a3" stroke="#fff" stroke-width="2"/>
+</svg>

--- a/assets/ui/icon-lock.svg
+++ b/assets/ui/icon-lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <rect x="10" y="20" width="28" height="20" rx="4" ry="4" fill="#666" stroke="#fff"/>
+  <path d="M16 20v-6a8 8 0 0 1 16 0v6" fill="none" stroke="#fff" stroke-width="4"/>
+</svg>

--- a/assets/ui/icon-nebula.svg
+++ b/assets/ui/icon-nebula.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <path d="M24 4c10 0 20 6 20 20s-10 20-20 20S4 38 4 24 14 4 24 4z" fill="#823"/>
+  <circle cx="24" cy="24" r="10" fill="#a0f" opacity="0.6"/>
+</svg>

--- a/assets/ui/icon-planet.svg
+++ b/assets/ui/icon-planet.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="18" fill="#44f" stroke="#fff" stroke-width="2"/>
+</svg>

--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -17,6 +17,10 @@ export class GameStateStore {
         cores: 0,
         magmaton: 0,
       },
+      sectors: [],
+      ui: {
+        unlockSectorId: null,
+      },
     };
     this.listeners = new Map();
   }
@@ -86,6 +90,37 @@ export class GameStateStore {
     p.destroyed = false;
     p.coreExtractable = false;
     p.dustSinceSpawn = 0;
+    this.emit('update', this.state);
+  }
+
+  initSectors(list) {
+    this.state.sectors = list.map((s) => ({ ...s }));
+    this.emit('update', this.state);
+  }
+
+  openUnlockModal(id) {
+    this.state.ui.unlockSectorId = id;
+    this.emit('update', this.state);
+  }
+
+  closeUnlockModal() {
+    this.state.ui.unlockSectorId = null;
+    this.emit('update', this.state);
+  }
+
+  unlockSector(id) {
+    const sector = this.state.sectors.find((s) => s.id === id);
+    if (!sector || sector.unlocked) return false;
+    if (this.state.resources.dust < sector.cost) return false;
+    this.state.resources.dust -= sector.cost;
+    sector.unlocked = true;
+    this.state.ui.unlockSectorId = null;
+    this.emit('update', this.state);
+    return true;
+  }
+
+  unlockAllSectors() {
+    this.state.sectors.forEach((s) => (s.unlocked = true));
     this.emit('update', this.state);
   }
 }

--- a/src/data/galaxy.js
+++ b/src/data/galaxy.js
@@ -1,0 +1,18 @@
+export const sectors = Array.from({ length: 10 }).map((_, i) => {
+  const id = `S${i + 1}`;
+  const x = i % 5;
+  const y = Math.floor(i / 5);
+  return {
+    id,
+    position: { x, y },
+    unlocked: i < 2, // first two unlocked
+    cost: 20 * (i + 1),
+    entities: [
+      {
+        id: `${id}-P1`,
+        type: 'planet',
+        name: `Planet ${i + 1}`,
+      },
+    ],
+  };
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,14 @@ import './style.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { app, stateManager, store } from './core/GameEngine.js';
+import { sectors as defaultSectors } from './data/galaxy.js';
 import { DevPanel } from './ui/DevPanel.tsx';
 import { BottomNavBar } from './ui/BottomNavBar.tsx';
 import { CurrencyHUD } from './ui/CurrencyHUD.tsx';
 import { WeaponPanel } from './ui/WeaponPanel.tsx';
 import { RewardDustPopup } from './ui/RewardDustPopup.tsx';
 import { RewardCorePopup } from './ui/RewardCorePopup.tsx';
+import { UnlockSectorModal } from './ui/UnlockSectorModal.tsx';
 
 const container = document.getElementById('canvas-container');
 container.appendChild(app.view);
@@ -15,21 +17,28 @@ app.view.id = 'game-canvas';
 app.view.style.width = '100%';
 app.view.style.height = '100%';
 
+// initialize galaxy sectors once
+store.initSectors(defaultSectors);
+
 
 function UI() {
   const [dustReward, setDustReward] = React.useState<number | null>(null);
   const [coreReward, setCoreReward] = React.useState<number | null>(null);
+  const [unlockId, setUnlockId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     const dustCb = ({ amount, source }: any) => {
       if (source !== 'attack') setDustReward(amount);
     };
     const coreCb = ({ amount }: any) => setCoreReward(amount);
+    const uiCb = (s: any) => setUnlockId(s.ui.unlockSectorId);
     store.on('reward:dust', dustCb);
     store.on('reward:core', coreCb);
+    store.on('update', uiCb);
     return () => {
       store.off('reward:dust', dustCb);
       store.off('reward:core', coreCb);
+      store.off('update', uiCb);
     };
   }, []);
 
@@ -42,6 +51,13 @@ function UI() {
       )}
       {coreReward !== null && (
         <RewardCorePopup amount={coreReward} onClose={() => setCoreReward(null)} />
+      )}
+      {unlockId && (
+        <UnlockSectorModal
+          sectorId={unlockId}
+          onClose={() => store.closeUnlockModal()}
+          onUnlock={() => store.unlockSector(unlockId)}
+        />
       )}
       <DevPanel />
       <BottomNavBar />

--- a/src/screens/GalaxyMap.js
+++ b/src/screens/GalaxyMap.js
@@ -1,22 +1,101 @@
 import * as PIXI from 'pixi.js';
+import { store } from '../core/GameEngine.js';
 
 export class GalaxyMap extends PIXI.Container {
   constructor(app, manager) {
     super();
     this.screenId = 'GalaxyMap';
-    const label = new PIXI.Text('Galaxy Map', { fill: 'white' });
-    label.anchor.set(0.5);
-    label.x = app.renderer.width / 2;
-    label.y = app.renderer.height / 2;
-    this.addChild(label);
+    this.app = app;
+    this.manager = manager;
 
-    const backBtn = new PIXI.Text('Вернуться', { fill: 'yellow', fontSize: 14 });
-    backBtn.interactive = true;
-    backBtn.buttonMode = true;
-    backBtn.anchor.set(0.5);
-    backBtn.x = app.renderer.width / 2;
-    backBtn.y = app.renderer.height - 60;
-    backBtn.on('pointertap', () => manager.goBack());
-    this.addChild(backBtn);
+    this.mapLayer = new PIXI.Container();
+    this.addChild(this.mapLayer);
+
+    this.createBackButton();
+    this.renderMap(store.get());
+    this.updateCb = (s) => this.renderMap(s);
+    store.on('update', this.updateCb);
+  }
+
+  createBackButton() {
+    const { width, height } = this.app.renderer;
+    const btn = new PIXI.Text('Back', { fill: 'yellow', fontSize: 14 });
+    btn.anchor.set(0.5);
+    btn.x = width / 2;
+    btn.y = height - 30;
+    btn.eventMode = 'static';
+    btn.cursor = 'pointer';
+    btn.on('pointertap', () => this.manager.goBack());
+    this.addChild(btn);
+  }
+
+  renderMap(state) {
+    this.mapLayer.removeChildren();
+    const size = Math.min(this.app.renderer.width / 5, this.app.renderer.height / 3);
+    state.sectors.forEach((sector) => {
+      const g = new PIXI.Graphics();
+      g.lineStyle(2, 0xffffff);
+      g.beginFill(sector.unlocked ? 0x334488 : 0x222222);
+      g.drawRect(0, 0, size - 8, size - 8);
+      g.endFill();
+      g.x = sector.position.x * size + 4;
+      g.y = sector.position.y * size + 4;
+      g.eventMode = 'static';
+      g.cursor = 'pointer';
+      g.on('pointertap', () => this.onSectorTap(sector));
+      this.mapLayer.addChild(g);
+
+      const label = new PIXI.Text(sector.id, { fill: 'white', fontSize: 12 });
+      label.anchor.set(0.5);
+      label.x = g.x + (size - 8) / 2;
+      label.y = g.y + 12;
+      this.mapLayer.addChild(label);
+
+      if (!sector.unlocked) {
+        const lock = PIXI.Sprite.from('/assets/ui/icon-lock.svg');
+        lock.anchor.set(0.5);
+        lock.x = g.x + (size - 8) / 2;
+        lock.y = g.y + (size - 8) / 2;
+        lock.scale.set(0.5);
+        this.mapLayer.addChild(lock);
+      } else {
+        sector.entities.forEach((ent, idx) => {
+          const icon = PIXI.Sprite.from(`/assets/ui/icon-${ent.type}.svg`);
+          icon.anchor.set(0.5);
+          icon.x = g.x + (size - 8) / 2;
+          icon.y = g.y + (size - 8) / 2 + idx * 20;
+          icon.scale.set(0.5);
+          icon.eventMode = 'static';
+          icon.cursor = 'pointer';
+          icon.on('pointertap', () => this.onEntityTap(ent));
+          this.mapLayer.addChild(icon);
+        });
+      }
+    });
+  }
+
+  onSectorTap(sector) {
+    if (!sector.unlocked) {
+      store.openUnlockModal(sector.id);
+    }
+  }
+
+  onEntityTap(ent) {
+    store.set({
+      planet: {
+        name: ent.name,
+        hp: 100,
+        maxHp: 100,
+        destroyed: false,
+        coreExtractable: false,
+        dustSinceSpawn: 0,
+      },
+    });
+    this.manager.goTo('MainScreen');
+  }
+
+  destroy(opts) {
+    store.off('update', this.updateCb);
+    super.destroy(opts);
   }
 }

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -1,5 +1,5 @@
 import * as PIXI from 'pixi.js';
-import { store } from '../core/GameEngine.js';
+import { store, stateManager } from '../core/GameEngine.js';
 import { weaponSystem } from '../core/WeaponSystem.js';
 import { PlanetMask } from '../core/PlanetMask.js';
 import { BrushManager } from '../core/BrushManager.js';
@@ -23,6 +23,15 @@ export class MainScreen extends PIXI.Container {
 
     this.projectileLayer = new PIXI.Container();
     this.addChild(this.projectileLayer);
+
+    const galaxyBtn = new PIXI.Text('Galaxy', { fill: 'yellow', fontSize: 14 });
+    galaxyBtn.anchor.set(1, 0);
+    galaxyBtn.x = width - 10;
+    galaxyBtn.y = 10;
+    galaxyBtn.eventMode = 'static';
+    galaxyBtn.cursor = 'pointer';
+    galaxyBtn.on('pointertap', () => stateManager.goTo('GalaxyMap'));
+    this.addChild(galaxyBtn);
 
     this.glow = new PIXI.Graphics();
     this.glow.beginFill(0x6666ff, 0.4);

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -67,6 +67,12 @@ export const DevPanel = () => {
             >
               Instant Dispatch
             </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => store.unlockAllSectors()}
+            >
+              Unlock all sectors
+            </button>
             <div className="flex gap-1 mt-2">
               {BrushManager.brushes.map((b) => (
                 <button

--- a/src/ui/ModalButton.tsx
+++ b/src/ui/ModalButton.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 interface Props {
   label: string;
   onClick: () => void;
+  icon?: string;
+  subtext?: string;
   disabled?: boolean;
+  loading?: boolean;
   styleType?: 'primary' | 'secondary' | 'destructive';
 }
 
-export const ModalButton = ({ label, onClick, disabled, styleType = 'primary' }: Props) => {
+export const ModalButton = ({ label, onClick, icon, subtext, disabled, loading, styleType = 'primary' }: Props) => {
   const base =
     styleType === 'destructive'
       ? 'bg-red-600'
@@ -16,11 +19,19 @@ export const ModalButton = ({ label, onClick, disabled, styleType = 'primary' }:
       : 'bg-blue-600';
   return (
     <button
-      className={`${base} text-white w-full py-2 rounded disabled:opacity-50`}
+      className={`${base} text-white w-full py-2 rounded disabled:opacity-50 flex flex-col items-center justify-center`}
       onClick={onClick}
-      disabled={disabled}
+      disabled={disabled || loading}
     >
-      {label}
+      {loading ? (
+        <span className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+      ) : (
+        <>
+          {icon && <img src={icon} className="w-5 h-5 mb-1" />}
+          <span>{label}</span>
+          {subtext && <span className="text-xs leading-none">{subtext}</span>}
+        </>
+      )}
     </button>
   );
 };

--- a/src/ui/UnlockSectorModal.tsx
+++ b/src/ui/UnlockSectorModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { store } from '../core/GameEngine.js';
+import { ModalButton } from './ModalButton.tsx';
+
+interface Props {
+  sectorId: string;
+  onClose: () => void;
+  onUnlock: () => void;
+}
+
+export const UnlockSectorModal = ({ sectorId, onClose, onUnlock }: Props) => {
+  const sector = store.get().sectors.find((s) => s.id === sectorId);
+  if (!sector) return null;
+  const resources = store.get().resources;
+  const canAfford = resources.dust >= sector.cost;
+  return (
+    <div
+      className="absolute inset-0 z-[300] bg-black/60 flex items-center justify-center pointer-events-auto animate-fadeIn"
+      onClick={onClose}
+    >
+      <div
+        className="bg-gray-800 text-white p-4 rounded w-3/4 max-w-xs"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-lg mb-2 text-center">Unlock {sector.id}</div>
+        <div className="flex items-center justify-center mb-3 gap-2">
+          <img src="/assets/ui/icon-dust.svg" className="w-6 h-6" />
+          <span className={canAfford ? '' : 'text-red-400'}>{sector.cost}</span>
+        </div>
+        <p className="text-sm text-center mb-3">Are you sure you want to unlock this sector?</p>
+        <div className="space-y-2">
+          <ModalButton
+            label="Unlock"
+            onClick={() => canAfford && onUnlock()}
+            disabled={!canAfford}
+          />
+          <ModalButton label="Cancel" onClick={onClose} styleType="secondary" />
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add placeholder galaxy icons and lock symbol
- configure asset manifest for new icons
- define initial galaxy sector data
- expand `GameStateStore` with sector management and unlock logic
- update main UI to show `UnlockSectorModal`
- implement full galaxy map with entity entry and back button
- add Galaxy button on `MainScreen`
- update DevPanel with `Unlock all sectors` action
- improve `ModalButton` with icons, subtext and loading state

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864353986688322b90a4a2c80128dea