### PR TITLE
Implement sector map navigation

### DIFF
--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -65,6 +65,18 @@ export class GameStateStore {
     this.emit('update', this.state);
   }
 
+  selectPlanet(ent) {
+    this.state.planet = {
+      name: ent.name,
+      hp: 100,
+      maxHp: 100,
+      destroyed: false,
+      coreExtractable: false,
+      dustSinceSpawn: 0,
+    };
+    this.emit('update', this.state);
+  }
+
   damagePlanet(amount) {
     const p = this.state.planet;
     if (p.destroyed) return;

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -1,5 +1,6 @@
 import { MainScreen } from '../screens/MainScreen.js';
 import { GalaxyMap } from '../screens/GalaxyMap.js';
+import { SectorMap } from '../screens/SectorMap.js';
 import { Profile } from '../screens/Profile.js';
 import { Store } from '../screens/Store.js';
 import { Earn } from '../screens/Earn.js';
@@ -8,6 +9,7 @@ import { Friends } from '../screens/Friends.js';
 const registry = {
   MainScreen,
   GalaxyMap,
+  SectorMap,
   Profile,
   Store,
   Earn,

--- a/src/data/galaxy.js
+++ b/src/data/galaxy.js
@@ -1,18 +1,112 @@
-export const sectors = Array.from({ length: 10 }).map((_, i) => {
-  const id = `S${i + 1}`;
-  const x = i % 5;
-  const y = Math.floor(i / 5);
-  return {
-    id,
-    position: { x, y },
-    unlocked: i < 2, // first two unlocked
-    cost: 20 * (i + 1),
+export const sectors = [
+  {
+    id: 'S1',
+    position: { x: 2, y: 0 },
+    unlocked: true,
+    cost: 20,
     entities: [
-      {
-        id: `${id}-P1`,
-        type: 'planet',
-        name: `Planet ${i + 1}`,
-      },
+      { id: 'S1-P1', type: 'planet', name: 'Alpha', position: { x: 30, y: 40 } },
+      { id: 'S1-P2', type: 'planet', name: 'Planet 1', position: { x: 60, y: 20 } },
+      { id: 'S1-P3', type: 'planet', name: 'Planet 2', position: { x: 80, y: 70 } },
     ],
-  };
-});
+  },
+  {
+    id: 'S2',
+    position: { x: 3, y: 0 },
+    unlocked: true,
+    cost: 40,
+    entities: [
+      { id: 'S2-P1', type: 'planet', name: 'Planet 1', position: { x: 25, y: 25 } },
+      { id: 'S2-P2', type: 'planet', name: 'Planet 2', position: { x: 65, y: 50 } },
+      { id: 'S2-P3', type: 'planet', name: 'Planet 3', position: { x: 45, y: 75 } },
+    ],
+  },
+  {
+    id: 'S3',
+    position: { x: 1, y: 1 },
+    unlocked: false,
+    cost: 60,
+    entities: [
+      { id: 'S3-P1', type: 'planet', name: 'Planet 1', position: { x: 20, y: 30 } },
+      { id: 'S3-P2', type: 'planet', name: 'Planet 2', position: { x: 50, y: 60 } },
+      { id: 'S3-P3', type: 'planet', name: 'Planet 3', position: { x: 80, y: 40 } },
+    ],
+  },
+  {
+    id: 'S4',
+    position: { x: 2, y: 1 },
+    unlocked: false,
+    cost: 80,
+    entities: [
+      { id: 'S4-P1', type: 'planet', name: 'Planet 1', position: { x: 30, y: 20 } },
+      { id: 'S4-P2', type: 'planet', name: 'Planet 2', position: { x: 70, y: 30 } },
+      { id: 'S4-P3', type: 'planet', name: 'Planet 3', position: { x: 50, y: 70 } },
+    ],
+  },
+  {
+    id: 'S5',
+    position: { x: 3, y: 1 },
+    unlocked: false,
+    cost: 100,
+    entities: [
+      { id: 'S5-P1', type: 'planet', name: 'Planet 1', position: { x: 40, y: 30 } },
+      { id: 'S5-P2', type: 'planet', name: 'Planet 2', position: { x: 60, y: 60 } },
+      { id: 'S5-P3', type: 'planet', name: 'Planet 3', position: { x: 80, y: 40 } },
+    ],
+  },
+  {
+    id: 'S6',
+    position: { x: 2, y: 2 },
+    unlocked: false,
+    cost: 120,
+    entities: [
+      { id: 'S6-P1', type: 'planet', name: 'Planet 1', position: { x: 25, y: 45 } },
+      { id: 'S6-P2', type: 'planet', name: 'Planet 2', position: { x: 55, y: 25 } },
+      { id: 'S6-P3', type: 'planet', name: 'Planet 3', position: { x: 75, y: 70 } },
+    ],
+  },
+  {
+    id: 'S7',
+    position: { x: 3, y: 2 },
+    unlocked: false,
+    cost: 140,
+    entities: [
+      { id: 'S7-P1', type: 'planet', name: 'Planet 1', position: { x: 30, y: 50 } },
+      { id: 'S7-P2', type: 'planet', name: 'Planet 2', position: { x: 60, y: 20 } },
+      { id: 'S7-P3', type: 'planet', name: 'Planet 3', position: { x: 80, y: 60 } },
+    ],
+  },
+  {
+    id: 'S8',
+    position: { x: 4, y: 2 },
+    unlocked: false,
+    cost: 160,
+    entities: [
+      { id: 'S8-P1', type: 'planet', name: 'Planet 1', position: { x: 20, y: 40 } },
+      { id: 'S8-P2', type: 'planet', name: 'Planet 2', position: { x: 50, y: 70 } },
+      { id: 'S8-P3', type: 'planet', name: 'Planet 3', position: { x: 75, y: 30 } },
+    ],
+  },
+  {
+    id: 'S9',
+    position: { x: 2, y: 3 },
+    unlocked: false,
+    cost: 180,
+    entities: [
+      { id: 'S9-P1', type: 'planet', name: 'Planet 1', position: { x: 35, y: 25 } },
+      { id: 'S9-P2', type: 'planet', name: 'Planet 2', position: { x: 60, y: 55 } },
+      { id: 'S9-P3', type: 'planet', name: 'Planet 3', position: { x: 80, y: 75 } },
+    ],
+  },
+  {
+    id: 'S10',
+    position: { x: 3, y: 3 },
+    unlocked: false,
+    cost: 200,
+    entities: [
+      { id: 'S10-P1', type: 'planet', name: 'Planet 1', position: { x: 30, y: 35 } },
+      { id: 'S10-P2', type: 'planet', name: 'Planet 2', position: { x: 55, y: 65 } },
+      { id: 'S10-P3', type: 'planet', name: 'Planet 3', position: { x: 75, y: 45 } },
+    ],
+  },
+];

--- a/src/screens/GalaxyMap.js
+++ b/src/screens/GalaxyMap.js
@@ -34,7 +34,11 @@ export class GalaxyMap extends PIXI.Container {
     const { width, height } = this.app.renderer;
     const cols = Math.max(...state.sectors.map((s) => s.position.x)) + 1;
     const rows = Math.max(...state.sectors.map((s) => s.position.y)) + 1;
-    const radius = Math.min(width / ((cols + 0.5) * Math.sqrt(3)), height / (rows * 1.5 + 0.5)) * 0.5;
+    const baseRadius = Math.min(
+      width / ((cols + 0.5) * Math.sqrt(3)),
+      height / (rows * 1.5 + 0.5)
+    ) * 0.5;
+    const radius = baseRadius * 1.3;
     const hexW = Math.sqrt(3) * radius;
     const hexH = 2 * radius;
     const horiz = hexW;
@@ -85,25 +89,15 @@ export class GalaxyMap extends PIXI.Container {
       store.openUnlockModal(sector.id);
       return;
     }
-    const ent = sector.entities && sector.entities[0];
-    if (ent) {
-      this.onEntityTap(ent);
+    if (sector.entities && sector.entities.length > 0) {
+      this.manager.goTo('SectorMap', { sectorId: sector.id });
     } else {
       window.alert('Sector empty');
     }
   }
 
   onEntityTap(ent) {
-    store.set({
-      planet: {
-        name: ent.name,
-        hp: 100,
-        maxHp: 100,
-        destroyed: false,
-        coreExtractable: false,
-        dustSinceSpawn: 0,
-      },
-    });
+    store.selectPlanet(ent);
     this.manager.goTo('MainScreen');
   }
 

--- a/src/screens/SectorMap.js
+++ b/src/screens/SectorMap.js
@@ -1,0 +1,80 @@
+import * as PIXI from 'pixi.js';
+import { store } from '../core/GameEngine.js';
+
+export class SectorMap extends PIXI.Container {
+  constructor(app, manager, params) {
+    super();
+    this.screenId = 'SectorMap';
+    this.app = app;
+    this.manager = manager;
+    this.sectorId = params.sectorId;
+
+    this.mapLayer = new PIXI.Container();
+    this.addChild(this.mapLayer);
+
+    this.createBackButton();
+    this.renderSector(store.get());
+    this.updateCb = (s) => this.renderSector(s);
+    store.on('update', this.updateCb);
+  }
+
+  createBackButton() {
+    const { width, height } = this.app.renderer;
+    const btn = new PIXI.Text('Back', { fill: 'yellow', fontSize: 14 });
+    btn.anchor.set(0.5);
+    btn.x = width / 2;
+    btn.y = height - 30;
+    btn.eventMode = 'static';
+    btn.cursor = 'pointer';
+    btn.on('pointertap', () => this.manager.goBack());
+    this.addChild(btn);
+  }
+
+  renderSector(state) {
+    this.mapLayer.removeChildren();
+    const sector = state.sectors.find((s) => s.id === this.sectorId);
+    if (!sector) return;
+    const { width, height } = this.app.renderer;
+    const size = Math.min(width, height) * 0.6;
+    const startX = (width - size) / 2;
+    const startY = (height - size) / 2;
+
+    const border = new PIXI.Graphics();
+    border.lineStyle(2, 0x555555);
+    border.beginFill(0x222222);
+    border.drawRect(startX, startY, size, size);
+    border.endFill();
+    this.mapLayer.addChild(border);
+
+    sector.entities.forEach((ent) => {
+      const x = startX + (ent.position.x / 100) * size;
+      const y = startY + (ent.position.y / 100) * size;
+      const g = new PIXI.Graphics();
+      g.beginFill(0x88aaff);
+      g.drawCircle(0, 0, 8);
+      g.endFill();
+      g.x = x;
+      g.y = y;
+      g.eventMode = 'static';
+      g.cursor = 'pointer';
+      g.on('pointertap', () => this.onPlanetTap(ent));
+      this.mapLayer.addChild(g);
+
+      const label = new PIXI.Text(ent.name, { fill: 'white', fontSize: 12 });
+      label.anchor.set(0.5, 0);
+      label.x = x;
+      label.y = y + 10;
+      this.mapLayer.addChild(label);
+    });
+  }
+
+  onPlanetTap(ent) {
+    store.selectPlanet(ent);
+    this.manager.goTo('MainScreen');
+  }
+
+  destroy(opts) {
+    store.off('update', this.updateCb);
+    super.destroy(opts);
+  }
+}


### PR DESCRIPTION
## Summary
- enlarge galaxy hex layout and arrange ring positions
- add fixed planet data per sector with Alpha at first slot
- enable selecting planets via new SectorMap screen
- update game store with selectPlanet helper
- wire new SectorMap in state manager

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68643bef11fc832292bc388cc26c9cd7