### PR TITLE
Fix missing Pixi filters on map screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@pixi/filter-blur": "^7.4.3",
+        "@pixi/filter-drop-shadow": "^5.2.0",
         "axios": "^1.10.0",
         "dotenv": "^17.0.0",
         "openai": "^5.8.2",
@@ -1022,6 +1024,18 @@
         "@pixi/core": "7.4.3"
       }
     },
+    "node_modules/@pixi/filter-drop-shadow": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-drop-shadow/-/filter-drop-shadow-5.2.0.tgz",
+      "integrity": "sha512-cYS2KDER7cwCu0V4VNSxTHGvzmNcEXdC9j3031YBOkUAE3+p17LMS/TAt6XeMfJV7KaPuusvXy2NFgGkv3RDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/filter-kawase-blur": "5.1.1"
+      },
+      "peerDependencies": {
+        "@pixi/core": "^7.0.0-X"
+      }
+    },
     "node_modules/@pixi/filter-fxaa": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
@@ -1029,6 +1043,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-kawase-blur": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-kawase-blur/-/filter-kawase-blur-5.1.1.tgz",
+      "integrity": "sha512-nPnJ1ChBFP+4pgFCwC0RJgHAJCetiHcQU3INH7zCdq88cFABmVmhN+wCKRNg4H7lF1EJjaXgFDkTrTreOD/bnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "^7.0.0-X"
       }
     },
     "node_modules/@pixi/filter-noise": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dotenv": "^17.0.0",
     "openai": "^5.8.2",
     "pixi.js": "^7.2.4",
+    "@pixi/filter-blur": "^7.4.3",
+    "@pixi/filter-drop-shadow": "^5.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/screens/GalaxyMap.js
+++ b/src/screens/GalaxyMap.js
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import { DropShadowFilter } from '@pixi/filter-drop-shadow';
 import { store } from '../core/GameEngine.js';
 
 export class GalaxyMap extends PIXI.Container {
@@ -37,7 +38,7 @@ export class GalaxyMap extends PIXI.Container {
     icon.x = 6;
     icon.y = 6;
     icon.tint = 0xffffff;
-    icon.filters = [new PIXI.filters.DropShadowFilter({ blur: 2, alpha: 0.8 })];
+    icon.filters = [new DropShadowFilter({ blur: 2, alpha: 0.8 })];
     hit.addChild(icon);
     this.addChild(hit);
   }

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import { BlurFilter } from '@pixi/filter-blur';
 import { store, stateManager } from '../core/GameEngine.js';
 import { weaponSystem } from '../core/WeaponSystem.js';
 import { PlanetMask } from '../core/PlanetMask.js';
@@ -29,7 +30,7 @@ export class MainScreen extends PIXI.Container {
     this.glow.beginFill(0xffffff, 0.4);
     this.glow.drawCircle(0, 0, this.radius * 1.2);
     this.glow.endFill();
-    this.glow.filters = [new PIXI.filters.BlurFilter(8)];
+    this.glow.filters = [new BlurFilter(8)];
     this.planetContainer.addChild(this.glow);
     this.glowPulse = 0;
     PIXI.Ticker.shared.add(this.pulseGlow, this);
@@ -245,7 +246,7 @@ export class MainScreen extends PIXI.Container {
     g.beginFill(0xffffff, 0.6);
     g.drawCircle(0, 0, r * 1.2);
     g.endFill();
-    g.filters = [new PIXI.filters.BlurFilter(4)];
+    g.filters = [new BlurFilter(4)];
     g.x = x;
     g.y = y;
     this.effectLayer.addChild(g);

--- a/src/screens/SectorMap.js
+++ b/src/screens/SectorMap.js
@@ -1,4 +1,6 @@
 import * as PIXI from 'pixi.js';
+import { DropShadowFilter } from '@pixi/filter-drop-shadow';
+import { BlurFilter } from '@pixi/filter-blur';
 import { store } from '../core/GameEngine.js';
 
 export class SectorMap extends PIXI.Container {
@@ -38,7 +40,7 @@ export class SectorMap extends PIXI.Container {
     icon.x = 6;
     icon.y = 6;
     icon.tint = 0xffffff;
-    icon.filters = [new PIXI.filters.DropShadowFilter({ blur: 2, alpha: 0.8 })];
+    icon.filters = [new DropShadowFilter({ blur: 2, alpha: 0.8 })];
     hit.addChild(icon);
     this.addChild(hit);
   }
@@ -69,7 +71,7 @@ export class SectorMap extends PIXI.Container {
       glow.beginFill(ent.glowColor, 0.6);
       glow.drawCircle(0, 0, radius * 1.4);
       glow.endFill();
-      glow.filters = [new PIXI.filters.BlurFilter(4)];
+      glow.filters = [new BlurFilter(4)];
       glow.x = x;
       glow.y = y;
       this.mapLayer.addChild(glow);


### PR DESCRIPTION
## Summary
- add `@pixi/filter-blur` and `@pixi/filter-drop-shadow` packages
- use DropShadowFilter and BlurFilter instances directly in screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686447c2ff3c8322a57a9cd6816b994f