### PR TITLE
Implement Destroy/Colonize flows

### DIFF
--- a/src/core/ColonySystem.js
+++ b/src/core/ColonySystem.js
@@ -1,0 +1,45 @@
+export class ColonySystem {
+  constructor(store) {
+    this.store = store;
+  }
+
+  update() {
+    const now = Date.now();
+    let changed = false;
+    this.store.state.sectors.forEach((sector) => {
+      sector.entities.forEach((p) => {
+        if (p.colony) {
+          if (!p.lastIncomeAt) p.lastIncomeAt = now;
+          const rate = (p.dustPerHour || 50) / 3600000;
+          const delta = now - p.lastIncomeAt;
+          if (delta > 0) {
+            p.storedDust = (p.storedDust || 0) + delta * rate;
+            p.lastIncomeAt = now;
+            changed = true;
+          }
+        }
+      });
+    });
+    if (changed) this.store.emit('update', this.store.state);
+  }
+
+  collect(planetId) {
+    const planet = this._findPlanet(planetId);
+    if (!planet || !planet.colony) return 0;
+    const amount = Math.floor(planet.storedDust || 0);
+    if (amount <= 0) return 0;
+    planet.storedDust -= amount;
+    planet.lastCollectionAt = Date.now();
+    this.store.addDust(amount, 'colony');
+    this.store.emit('update', this.store.state);
+    return amount;
+  }
+
+  _findPlanet(id) {
+    for (const s of this.store.state.sectors) {
+      const p = s.entities.find((e) => e.id === id);
+      if (p) return p;
+    }
+    return null;
+  }
+}

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -3,6 +3,8 @@ import { GameStateStore } from './GameStateStore.js';
 import { StateManager } from './StateManager.js';
 import { DispatchSystem } from './DispatchSystem.js';
 import { NebulaSystem } from './NebulaSystem.js';
+import { ColonySystem } from './ColonySystem.js';
+import { SaveManager } from './SaveManager.js';
 
 export const store = new GameStateStore();
 
@@ -17,3 +19,11 @@ export const app = new PIXI.Application({
 export const stateManager = new StateManager(store, app);
 export const dispatchSystem = new DispatchSystem(store);
 export const nebulaSystem = new NebulaSystem(store);
+export const colonySystem = new ColonySystem(store);
+
+const saved = SaveManager.load();
+if (saved) {
+  store.load(saved);
+}
+store.on('update', (s) => SaveManager.save(s));
+

--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -11,6 +11,11 @@ export class GameStateStore {
         destroyed: false,
         coreExtractable: false,
         dustSinceSpawn: 0,
+        colony: false,
+        choiceMade: false,
+        dustPerHour: 50,
+        storedDust: 0,
+        lastIncomeAt: 0,
       },
       resources: {
         dust: 0,
@@ -125,6 +130,50 @@ export class GameStateStore {
     this.emit('update', this.state);
   }
 
+  load(data) {
+    this.state = data;
+    this.emit('update', this.state);
+  }
+
+  chooseDestroy() {
+    const p = this.state.planet;
+    p.choiceMade = true;
+    this.emit('update', this.state);
+  }
+
+  chooseColonize() {
+    const p = this.state.planet;
+    p.choiceMade = true;
+    p.colony = true;
+    p.destroyed = false;
+    p.hp = p.maxHp;
+    p.coreExtractable = false;
+    p.storedDust = 0;
+    p.lastIncomeAt = Date.now();
+    this.emit('update', this.state);
+  }
+
+  collectColonyDust() {
+    const p = this.state.planet;
+    if (!p.colony) return 0;
+    const amount = Math.floor(p.storedDust || 0);
+    if (amount <= 0) return 0;
+    p.storedDust -= amount;
+    p.lastCollectionAt = Date.now();
+    this.addDust(amount, 'colony');
+    this.emit('update', this.state);
+    return amount;
+  }
+
+  collectCore() {
+    const p = this.state.planet;
+    if (!p.coreExtractable) return false;
+    this.addCore(1, 'dispatch');
+    p.coreExtractable = false;
+    this.emit('update', this.state);
+    return true;
+  }
+
   initSectors(list) {
     const used = new Set();
     this.state.sectors = list.map((s) => {
@@ -147,6 +196,10 @@ export class GameStateStore {
             coreExtractable: false,
             dustSinceSpawn: 0,
             colony: false,
+            choiceMade: false,
+            dustPerHour: 50,
+            storedDust: 0,
+            lastIncomeAt: 0,
             surfaceColor: surface,
             glowColor: glow,
           });
@@ -226,3 +279,4 @@ export class GameStateStore {
     this.emit('update', this.state);
   }
 }
+

--- a/src/core/SaveManager.js
+++ b/src/core/SaveManager.js
@@ -1,0 +1,20 @@
+export class SaveManager {
+  static save(state) {
+    try {
+      localStorage.setItem('pd_save', JSON.stringify(state));
+    } catch (e) {
+      // ignore quota errors
+    }
+  }
+
+  static load() {
+    try {
+      const raw = localStorage.getItem('pd_save');
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (e) {
+      return null;
+    }
+  }
+}
+

--- a/src/core/WeaponSystem.js
+++ b/src/core/WeaponSystem.js
@@ -19,7 +19,8 @@ class WeaponSystem {
 
   fire() {
     if (this.weapon.ammo <= 0) return 0;
-    if (store.state.planet.destroyed) return 0;
+    const p = store.state.planet;
+    if (p.destroyed || p.colony || !p.choiceMade) return 0;
     this.weapon.ammo -= 1;
     store.emit('update', store.state);
     return this.weapon.damage;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import './style.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { app, stateManager, store, dispatchSystem, nebulaSystem } from './core/GameEngine.js';
+import { app, stateManager, store, dispatchSystem, nebulaSystem, colonySystem } from './core/GameEngine.js';
 import { sectors as defaultSectors } from './data/galaxy.js';
 import { planetNames } from './data/planetNames.js';
 import { DevPanel } from './ui/DevPanel.tsx';
@@ -12,6 +12,8 @@ import { GalaxyButton } from './ui/GalaxyButton.tsx';
 import { RewardDustPopup } from './ui/RewardDustPopup.tsx';
 import { RewardCorePopup } from './ui/RewardCorePopup.tsx';
 import { UnlockSectorModal } from './ui/UnlockSectorModal.tsx';
+import { PlanetActionModal } from './ui/PlanetActionModal.tsx';
+import { ColonyPanel } from './ui/ColonyPanel.tsx';
 
 const container = document.getElementById('canvas-container');
 container.appendChild(app.view);
@@ -53,7 +55,9 @@ function UI() {
     <div className="absolute inset-0 flex flex-col justify-between items-center pointer-events-none">
       <CurrencyHUD />
       <WeaponPanel />
+      <ColonyPanel />
       <GalaxyButton />
+      <PlanetActionModal />
       {dustReward !== null && (
         <RewardDustPopup amount={dustReward} onClose={() => setDustReward(null)} />
       )}
@@ -80,6 +84,7 @@ stateManager.goTo('MainScreen');
 
 setInterval(() => {
   dispatchSystem.update();
+  colonySystem.update();
 }, 1000);
 
 // expose for debugging

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -110,9 +110,19 @@ export class MainScreen extends PIXI.Container {
 
     const ratio = p.hp / p.maxHp;
     this.hpBar.clear();
-    this.hpBar.beginFill(0xff4444);
-    this.hpBar.drawRoundedRect(-this.radius, -this.radius - 24, this.radius * 2 * ratio, 16, 8);
-    this.hpBar.endFill();
+    if (!p.colony) {
+      this.hpBar.beginFill(0xff4444);
+      this.hpBar.drawRoundedRect(
+        -this.radius,
+        -this.radius - 24,
+        this.radius * 2 * ratio,
+        16,
+        8
+      );
+      this.hpBar.endFill();
+    }
+    this.hpBg.visible = !p.colony;
+    this.hpText.visible = !p.colony;
     this.hpText.text = `${p.hp}/${p.maxHp}`;
 
     this.nameLabel.text = p.name;

--- a/src/ui/ColonyPanel.tsx
+++ b/src/ui/ColonyPanel.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { colonySystem, store } from '../core/GameEngine.js';
+
+export const ColonyPanel = () => {
+  const [planet, setPlanet] = useState(store.get().planet);
+  const [screen, setScreen] = useState(store.get().currentScreen);
+  useEffect(() => {
+    const cb = (s: any) => {
+      setPlanet({ ...s.planet });
+      setScreen(s.currentScreen);
+    };
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+  if (screen !== 'MainScreen' || !planet.colony) return null;
+  const stored = Math.floor(planet.storedDust || 0);
+  return (
+    <div className="absolute bottom-20 left-0 right-0 flex flex-col items-center gap-y-2 pointer-events-auto animate-fadeIn">
+      <div className="flex items-center gap-x-1 text-white">
+        <img src="/assets/ui/icon-dust.svg" className="w-5 h-5" />
+        <span>{stored}</span>
+      </div>
+      <button
+        className="bg-green-600 text-white px-4 py-2 rounded min-w-[88px] min-h-[44px]"
+        onClick={() => colonySystem.collect(planet.id)}
+      >
+        Collect
+      </button>
+    </div>
+  );
+};
+

--- a/src/ui/PlanetActionModal.tsx
+++ b/src/ui/PlanetActionModal.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { store } from '../core/GameEngine.js';
+import { ModalButton } from './ModalButton.tsx';
+
+export const PlanetActionModal = () => {
+  const planet = store.get().planet;
+  if (planet.choiceMade || planet.destroyed || planet.colony) return null;
+  return (
+    <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-[200] pointer-events-auto">
+      <div className="bg-gray-800 text-white p-4 rounded w-3/4 max-w-xs space-y-3" onClick={(e) => e.stopPropagation()}>
+        <p className="text-center text-lg">Choose your action</p>
+        <ModalButton label="Destroy" styleType="destructive" onClick={() => store.chooseDestroy()} />
+        <ModalButton label="Colonize" onClick={() => store.chooseColonize()} />
+      </div>
+    </div>
+  );
+};
+

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -22,7 +22,7 @@ export const WeaponPanel = () => {
     };
   }, []);
 
-  if (screen !== 'MainScreen') return null;
+  if (screen !== 'MainScreen' || planet.colony || !planet.choiceMade) return null;
 
   return (
     <div className="absolute bottom-16 left-0 right-0 flex flex-col items-center gap-y-4 pb-6 pointer-events-auto animate-fadeIn">
@@ -56,8 +56,7 @@ export const WeaponPanel = () => {
         <button
           className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"
           onClick={() => {
-            store.addCore(1, 'dispatch');
-            store.resetPlanet();
+            store.collectCore();
           }}
         >
           Send Unit


### PR DESCRIPTION
## Summary
- add colony income system and persistence
- implement choice modal for new planets
- show colony panel with dust generation
- block weapons for colonies and before action choice
- persist game state using SaveManager

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686450b6f33c8322bcd80e55ddc3d7fe