### PR TITLE
Add colony icon and improve flyouts

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,7 +39,7 @@ function UI() {
 
   React.useEffect(() => {
     const dustCb = ({ amount, source }: any) => {
-      if (source !== 'attack') setDustReward(amount);
+      if (source !== 'attack' && source !== 'colonyTap') setDustReward(amount);
     };
     const flyoutCb = ({ amount }: any) => {
       const id = Date.now() + Math.random();

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -176,7 +176,7 @@ export class MainScreen extends PIXI.Container {
     this.nameLabel.text = p.name;
     this.colonyIcon.visible = p.colony;
     if (p.colony) {
-      this.colonyIcon.x = this.nameLabel.width / 2 + 14;
+      this.colonyIcon.x = -this.nameLabel.width / 2 - 14;
       this.colonyIcon.y = this.nameLabel.y;
     }
   }

--- a/src/screens/SectorMap.js
+++ b/src/screens/SectorMap.js
@@ -93,6 +93,16 @@ export class SectorMap extends PIXI.Container {
       label.x = x;
       label.y = y - radius - 4;
       this.mapLayer.addChild(label);
+
+      if (ent.colony) {
+        const icon = PIXI.Sprite.from('/assets/ui/icon-colony.svg');
+        icon.anchor.set(0.5);
+        icon.width = 24;
+        icon.height = 24;
+        icon.x = label.x - label.width / 2 - 14;
+        icon.y = label.y;
+        this.mapLayer.addChild(icon);
+      }
     });
   }
 

--- a/src/ui/DustFlyout.tsx
+++ b/src/ui/DustFlyout.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const DustFlyout = ({ amount }: Props) => {
   return (
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-10 text-yellow-300 font-bold pointer-events-none animate-flyout">
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-10 text-yellow-300 text-4xl font-bold pointer-events-none animate-flyout">
       +{amount}
     </div>
   );


### PR DESCRIPTION
## Summary
- enlarge Dust flyout text
- suppress reward popup for colony taps
- show colony icon left of planet name on main screen
- render colony icon on sector map labels

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686457f697b48322969a940fa74b9763