### PR TITLE
Implement core extraction & status system

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import { UnlockSectorModal } from './ui/UnlockSectorModal.tsx';
 import { PlanetActionModal } from './ui/PlanetActionModal.tsx';
 import { ColonyPanel } from './ui/ColonyPanel.tsx';
 import { DustFlyout } from './ui/DustFlyout.tsx';
+import { ExtractionPanel } from './ui/ExtractionPanel.tsx';
 
 const container = document.getElementById('canvas-container');
 container.appendChild(app.view);
@@ -64,6 +65,7 @@ function UI() {
     <div className="absolute inset-0 flex flex-col justify-between items-center pointer-events-none">
       <CurrencyHUD />
       <WeaponPanel />
+      <ExtractionPanel />
       <ColonyPanel />
       <GalaxyButton />
       <PlanetActionModal />
@@ -97,6 +99,7 @@ stateManager.goTo('MainScreen');
 setInterval(() => {
   dispatchSystem.update();
   colonySystem.update();
+  store.updateExtractions();
 }, 1000);
 
 // expose for debugging

--- a/src/screens/SectorMap.js
+++ b/src/screens/SectorMap.js
@@ -77,7 +77,13 @@ export class SectorMap extends PIXI.Container {
       this.mapLayer.addChild(glow);
 
       const g = new PIXI.Graphics();
-      g.beginFill(ent.surfaceColor);
+      let color = ent.surfaceColor;
+      if (ent.status === 'destroyed' || ent.status === 'extracting') {
+        color = 0x666666;
+      } else if (ent.status === 'empty') {
+        color = 0x333333;
+      }
+      g.beginFill(color);
       g.drawCircle(0, 0, radius);
       g.endFill();
       g.x = x;

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -37,7 +37,7 @@ export const DevPanel = () => {
               className="bg-blue-500 px-2 py-1 mt-1"
               onClick={() => store.resetPlanet()}
             >
-              Reset HP
+              Reset Planet
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"
@@ -59,25 +59,21 @@ export const DevPanel = () => {
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"
-              onClick={() => {
-                const scr: any = stateManager.current;
-                if (scr && typeof scr.killPlanet === 'function') {
-                  scr.killPlanet();
-                } else {
-                  store.damagePlanet(store.state.planet.hp);
-                }
-              }}
+              onClick={() => store.damagePlanet(store.state.planet.hp)}
             >
-              Instant Kill
+              Force Destroy
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"
-              onClick={() => {
-                store.addCore(1, 'dev');
-                store.resetPlanet();
-              }}
+              onClick={() => store.chooseColonize()}
             >
-              Instant Dispatch
+              Force Colonize
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => store.startExtraction(1000)}
+            >
+              Force Extract
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"

--- a/src/ui/DustFlyout.tsx
+++ b/src/ui/DustFlyout.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const DustFlyout = ({ amount }: Props) => {
   return (
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-10 text-yellow-300 text-4xl font-bold pointer-events-none animate-flyout">
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-10 text-white text-4xl font-bold pointer-events-none animate-flyout">
       +{amount}
     </div>
   );

--- a/src/ui/ExtractionPanel.tsx
+++ b/src/ui/ExtractionPanel.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { store } from '../core/GameEngine.js';
+
+export const ExtractionPanel = () => {
+  const [planet, setPlanet] = useState(store.get().planet);
+
+  useEffect(() => {
+    const cb = (s: any) => setPlanet({ ...s.planet });
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
+  if (planet.status !== 'extracting' || !planet.extraction) return null;
+
+  const now = Date.now();
+  const elapsed = now - planet.extraction.startedAt;
+  const progress = Math.min(1, elapsed / planet.extraction.duration);
+  const remaining = Math.max(0, Math.ceil((planet.extraction.duration - elapsed) / 1000));
+
+  return (
+    <div className="absolute bottom-28 left-0 right-0 flex flex-col items-center pointer-events-none animate-fadeIn">
+      <div className="w-40 h-3 bg-gray-700 rounded overflow-hidden">
+        <div className="bg-blue-500 h-3" style={{ width: `${progress * 100}%` }}></div>
+      </div>
+      <div className="text-white text-sm mt-1 animate-pulse">{remaining}s</div>
+    </div>
+  );
+};

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -52,11 +52,11 @@ export const WeaponPanel = () => {
           </div>
         )}
       </div>
-      {planet.coreExtractable && (
+      {planet.status === 'destroyed' && (
         <button
           className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"
           onClick={() => {
-            store.collectCore();
+            store.startExtraction();
           }}
         >
           Send Unit


### PR DESCRIPTION
## Summary
- manage planet status in `GameStateStore`
- support starting and updating core extractions with persistence
- show extraction progress UI
- add developer shortcuts for planet status
- color fix for dust flyouts
- visualize planet status on sector map

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68645a2c98f4832291798de98ca19d4d