### PR TITLE
Implement core extraction completion

### DIFF
--- a/src/ui/DustFlyout.tsx
+++ b/src/ui/DustFlyout.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 
 interface Props {
   amount: number;
+  index: number;
 }
 
-export const DustFlyout = ({ amount }: Props) => {
+const positions = [
+  { x: -40, y: -30 },
+  { x: 40, y: -30 },
+  { x: 60, y: 0 },
+  { x: 40, y: 30 },
+  { x: -40, y: 30 },
+];
+
+export const DustFlyout = ({ amount, index }: Props) => {
+  const pos = positions[index % positions.length];
   return (
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-10 text-white text-4xl font-bold pointer-events-none animate-flyout">
+    <div
+      className="absolute left-1/2 top-1/2 text-white text-4xl font-bold pointer-events-none animate-flyout"
+      style={{ transform: `translate(-50%, -50%) translate(${pos.x}px, ${pos.y}px)` }}
+    >
       +{amount}
     </div>
   );

--- a/src/ui/RewardCorePopup.tsx
+++ b/src/ui/RewardCorePopup.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
+import { ModalButton } from './ModalButton.tsx';
 
 interface Props {
   amount: number;
+  planetName?: string;
   onClose: () => void;
 }
 
-export const RewardCorePopup = ({ amount, onClose }: Props) => {
+export const RewardCorePopup = ({ amount, planetName, onClose }: Props) => {
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-[200] pointer-events-auto">
-      <div className="bg-gray-800 text-white p-4 rounded text-center w-3/4 max-w-xs">
-        <div className="text-lg mb-2">Core Acquired</div>
-        <div className="text-2xl mb-4">+{amount}</div>
-        <button
-          className="bg-blue-600 w-full py-2 rounded"
-          onClick={onClose}
-        >
-          OK
-        </button>
+      <div
+        className="bg-gray-800 text-white p-4 rounded text-center w-3/4 max-w-xs space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-lg font-bold">
+          {planetName
+            ? `Planet ${planetName} — Core extraction completed`
+            : 'Core Acquired'}
+        </div>
+        <div className="flex items-center justify-center space-x-2">
+          <img src="/assets/ui/icon-core.svg" className="w-6 h-6" />
+          <span className="text-2xl">+{amount}</span>
+        </div>
+        <ModalButton label="Receive" onClick={onClose} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- emit `extraction:completed` event when timer finishes and provide planet info
- remove planets from sectors on popup close
- adjust core reward modal to show planet name and use `ModalButton`
- cycle dust flyout through 5 preset positions
- open SectorMap when extraction finishes on the active planet

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68645e4eec3c83229673394cb22c4836