### PR TITLE
Fix UI layout and extraction timer

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { DevPanel } from './ui/DevPanel.tsx';
 import { BottomNavBar } from './ui/BottomNavBar.tsx';
 import { CurrencyHUD } from './ui/CurrencyHUD.tsx';
 import { WeaponPanel } from './ui/WeaponPanel.tsx';
+import { PlanetHUD } from './ui/PlanetHUD.tsx';
 import { GalaxyButton } from './ui/GalaxyButton.tsx';
 import { RewardDustPopup } from './ui/RewardDustPopup.tsx';
 import { RewardCorePopup } from './ui/RewardCorePopup.tsx';
@@ -84,8 +85,9 @@ function UI() {
   return (
     <div className="absolute inset-0 flex flex-col justify-between items-center pointer-events-none">
       <CurrencyHUD />
-      <WeaponPanel />
+      <PlanetHUD />
       <ExtractionPanel />
+      <WeaponPanel />
       <ColonyPanel />
       <GalaxyButton />
       <PlanetActionModal />

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -101,6 +101,16 @@ export class MainScreen extends PIXI.Container {
     this.colonyIcon.visible = false;
     this.planetContainer.addChild(this.colonyIcon);
 
+    // hide built-in labels and bars, overlay handled by React HUD
+    this.hpBg.visible = false;
+    this.hpBar.visible = false;
+    this.hpText.visible = false;
+    this.dustBg.visible = false;
+    this.dustBar.visible = false;
+    this.dustText.visible = false;
+    this.nameLabel.visible = false;
+    this.colonyIcon.visible = false;
+
     this.planetContainer.eventMode = 'static';
     this.planetContainer.cursor = 'pointer';
     this.planetContainer.on('pointertap', () => {

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -19,20 +19,20 @@ export const BottomNavBar = () => {
   }, []);
 
   return (
-    <nav className="absolute bottom-0 left-0 right-0 flex justify-between bg-slate-800/70 border-t border-slate-700 text-white z-50 pointer-events-auto h-14 px-2 animate-fadeIn">
+    <nav className="absolute bottom-0 left-0 right-0 flex justify-between bg-slate-800/70 border-t border-slate-700 text-white z-50 pointer-events-auto h-14 px-2 overflow-hidden animate-fadeIn">
       {buttons.map((btn) => {
         const isActive = btn.id === active;
         return (
           <button
             key={btn.id}
-            className={`flex flex-col items-center flex-1 transition-transform min-w-[56px] py-1 ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
+            className={`flex flex-col items-center flex-1 transition-transform min-w-0 py-1 ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
             onClick={() => stateManager.goTo(btn.id)}
           >
             <img
               src={btn.icon}
               className={`${isActive ? 'w-10 h-10' : 'w-8 h-8'} mb-1 transition-transform`}
             />
-            <span className="text-xs">{btn.label}</span>
+            <span className="whitespace-nowrap overflow-hidden text-ellipsis text-[10px] mobile414:text-xs">{btn.label}</span>
           </button>
         );
       })}

--- a/src/ui/ExtractionPanel.tsx
+++ b/src/ui/ExtractionPanel.tsx
@@ -3,11 +3,29 @@ import { store } from '../core/GameEngine.js';
 
 export const ExtractionPanel = () => {
   const [planet, setPlanet] = useState(store.get().planet);
+  const [, tick] = useState(0);
 
   useEffect(() => {
     const cb = (s: any) => setPlanet({ ...s.planet });
     store.on('update', cb);
-    return () => store.off('update', cb);
+    let frame: number;
+    const loop = () => {
+      tick((t) => t + 1);
+      const p = store.get().planet;
+      if (
+        p.status === 'extracting' &&
+        p.extraction &&
+        Date.now() >= p.extraction.startedAt + p.extraction.duration
+      ) {
+        store.updateExtractions();
+      }
+      frame = requestAnimationFrame(loop);
+    };
+    frame = requestAnimationFrame(loop);
+    return () => {
+      store.off('update', cb);
+      cancelAnimationFrame(frame);
+    };
   }, []);
 
   if (planet.status !== 'extracting' || !planet.extraction) return null;
@@ -18,7 +36,7 @@ export const ExtractionPanel = () => {
   const remaining = Math.max(0, Math.ceil((planet.extraction.duration - elapsed) / 1000));
 
   return (
-    <div className="absolute bottom-28 left-0 right-0 flex flex-col items-center pointer-events-none animate-fadeIn">
+    <div className="absolute top-32 left-0 right-0 flex flex-col items-center pointer-events-none animate-fadeIn">
       <div className="w-40 h-3 bg-gray-700 rounded overflow-hidden">
         <div className="bg-blue-500 h-3" style={{ width: `${progress * 100}%` }}></div>
       </div>

--- a/src/ui/PlanetHUD.tsx
+++ b/src/ui/PlanetHUD.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { store } from '../core/GameEngine.js';
+
+export const PlanetHUD = () => {
+  const [planet, setPlanet] = useState(store.get().planet);
+
+  useEffect(() => {
+    const cb = (s: any) => setPlanet({ ...s.planet });
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
+  const hpRatio = planet.hp / planet.maxHp;
+  const dustRatio = Math.min(1, (planet.storedDust || 0) / 10000);
+
+  return (
+    <div className="absolute top-14 left-0 right-0 flex flex-col items-center pointer-events-none animate-fadeIn">
+      <div className="flex items-center gap-x-2">
+        {planet.colony && (
+          <img src="/assets/ui/icon-colony.svg" className="w-5 h-5" />
+        )}
+        <span className="text-white text-lg font-semibold">{planet.name}</span>
+      </div>
+      {!planet.colony && (
+        <div className="w-40 h-3 bg-gray-700 rounded overflow-hidden mt-1">
+          <div className="bg-red-500 h-3" style={{ width: `${hpRatio * 100}%` }}></div>
+        </div>
+      )}
+      {planet.colony && (
+        <div className="w-40 h-3 bg-gray-700 rounded overflow-hidden mt-1">
+          <div className="bg-yellow-500 h-3" style={{ width: `${dustRatio * 100}%` }}></div>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- show planet info overlay under currency HUD
- place extraction timer below planet status and update it every frame
- keep back button visible and maintain consistent icon style
- tweak bottom navbar text to avoid overflow
- hide old planet HUD elements rendered in Pixi

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864616e6bd88322bd8d14addd85820d