### PR TITLE
Implement layout zones and screen-specific HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
   <meta name="theme-color" content="#000000" />
   <title>Planet Destroyer</title>
   <style>
+    :root {
+      --hud-height: 64px;
+      --navbar-height: 56px;
+    }
     html, body {
       margin: 0;
       padding: 0;
@@ -36,10 +40,8 @@
         linear-gradient(180deg, #0d1d2d, #261345);
     }
     #canvas-container {
-      width: 100%;
-      height: 100%;
-      position: relative;
-      flex: 1 1 auto;
+      position: absolute;
+      inset: var(--hud-height) 0 var(--navbar-height);
     }
     #game-canvas,
     #ui-layer {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,8 @@ import { DustFlyout } from './ui/DustFlyout.tsx';
 import { ExtractionPanel } from './ui/ExtractionPanel.tsx';
 import { UnitReadyPopup } from './ui/UnitReadyPopup.tsx';
 
+const isDev = import.meta.env.DEV;
+
 const container = document.getElementById('canvas-container');
 container.appendChild(app.view);
 app.view.id = 'game-canvas';
@@ -43,6 +45,7 @@ function UI() {
   const [unlockId, setUnlockId] = React.useState<string | null>(null);
   const [flyouts, setFlyouts] = React.useState<{ id: number; amount: number; idx: number }[]>([]);
   const flyoutIndex = React.useRef(0);
+  const [screen, setScreen] = React.useState(store.get().currentScreen);
 
   React.useEffect(() => {
     const dustCb = ({ amount, source }: any) => {
@@ -71,9 +74,11 @@ function UI() {
       setExtractionInfo(info);
     };
     const uiCb = (s: any) => setUnlockId(s.ui.unlockSectorId);
+    const screenCb = (s: any) => setScreen(s.currentScreen);
     store.on('reward:dust', dustCb);
     store.on('reward:core', coreCb);
     store.on('update', uiCb);
+    store.on('update', screenCb);
     store.on('flyout', flyoutCb);
     const craftCb = (info: any) => setUnitReady(info);
     store.on('extraction:completed', extractionCb);
@@ -82,6 +87,7 @@ function UI() {
       store.off('reward:dust', dustCb);
       store.off('reward:core', coreCb);
       store.off('update', uiCb);
+      store.off('update', screenCb);
       store.off('flyout', flyoutCb);
       store.off('extraction:completed', extractionCb);
       store.off('craft:completed', craftCb);
@@ -89,15 +95,27 @@ function UI() {
   }, []);
 
   return (
-    <div className="absolute inset-0 flex flex-col justify-between items-center pointer-events-none">
-      <CurrencyHUD />
-      <BackButton />
-      <PlanetHUD />
-      <ExtractionPanel />
-      <WeaponPanel />
-      <ColonyPanel />
-      <GalaxyButton />
-      <PlanetActionModal />
+    <div className="absolute inset-0 pointer-events-none">
+      {screen === 'MainScreen' && (
+        <div
+          id="hud-layer"
+          className={`${isDev ? 'debug-outline' : ''} absolute top-0 left-0 right-0 pointer-events-none`}
+          style={{ height: 'var(--hud-height)' }}
+        >
+          <CurrencyHUD />
+          <PlanetHUD />
+        </div>
+      )}
+      <div
+        id="modal-layer"
+        className="absolute inset-0 pointer-events-none"
+      >
+        <BackButton />
+        <ExtractionPanel />
+        <WeaponPanel />
+        <ColonyPanel />
+        <GalaxyButton />
+        <PlanetActionModal />
       {flyouts.map((f) => (
         <DustFlyout key={f.id} amount={f.amount} index={f.idx} />
       ))}
@@ -133,8 +151,15 @@ function UI() {
           onUnlock={() => store.unlockSector(unlockId)}
         />
       )}
-      <DevPanel />
-      <BottomNavBar />
+        <DevPanel />
+      </div>
+      <div
+        id="navbar-layer"
+        className={`${isDev ? 'debug-outline' : ''} absolute bottom-0 left-0 right-0 pointer-events-none`}
+        style={{ height: 'var(--navbar-height)' }}
+      >
+        <BottomNavBar />
+      </div>
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.debug-outline {
+  outline: 1px dashed rgba(255, 0, 0, 0.6);
+}

--- a/src/ui/CurrencyHUD.tsx
+++ b/src/ui/CurrencyHUD.tsx
@@ -3,12 +3,20 @@ import { store, stateManager } from '../core/GameEngine.js';
 
 export const CurrencyHUD = () => {
   const [res, setRes] = useState(store.get().resources);
+  const [screen, setScreen] = useState(store.get().currentScreen);
 
   useEffect(() => {
     const cb = (s: any) => setRes({ ...s.resources });
+    const screenCb = (s: any) => setScreen(s.currentScreen);
     store.on('update', cb);
-    return () => store.off('update', cb);
+    store.on('update', screenCb);
+    return () => {
+      store.off('update', cb);
+      store.off('update', screenCb);
+    };
   }, []);
+
+  if (screen !== 'MainScreen') return null;
 
   return (
     <div className="absolute top-0 left-0 right-0 flex justify-between items-center px-2 py-3 bg-slate-800/70 border-b border-slate-700 pointer-events-auto animate-fadeIn">

--- a/src/ui/PlanetHUD.tsx
+++ b/src/ui/PlanetHUD.tsx
@@ -3,12 +3,20 @@ import { store } from '../core/GameEngine.js';
 
 export const PlanetHUD = () => {
   const [planet, setPlanet] = useState(store.get().planet);
+  const [screen, setScreen] = useState(store.get().currentScreen);
 
   useEffect(() => {
     const cb = (s: any) => setPlanet({ ...s.planet });
+    const screenCb = (s: any) => setScreen(s.currentScreen);
     store.on('update', cb);
-    return () => store.off('update', cb);
+    store.on('update', screenCb);
+    return () => {
+      store.off('update', cb);
+      store.off('update', screenCb);
+    };
   }, []);
+
+  if (screen !== 'MainScreen') return null;
 
   const hpRatio = planet.hp / planet.maxHp;
   const dustRatio = Math.min(1, (planet.storedDust || 0) / 10000);


### PR DESCRIPTION
## Summary
- enforce layout contract with CSS variables for HUD and navbar zones
- add debug-outline class
- hide CurrencyHUD and PlanetHUD when not on MainScreen
- restructure React UI layout for HUD, modal, and navbar layers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686510697b7c8322aeb02e4c43db3cfb