### PR TITLE
Fix canvas scaling via layout utils

### DIFF
--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -8,12 +8,13 @@ import { SaveManager } from './SaveManager.js';
 
 export const store = new GameStateStore();
 
-const wrapper = document.getElementById('wrapper');
+const canvasContainer = document.getElementById('canvas-container');
 
 export const app = new PIXI.Application({
-  resizeTo: wrapper,
+  resizeTo: canvasContainer,
   backgroundColor: 0x000000,
   antialias: true,
+  autoDensity: true,
 });
 
 export const stateManager = new StateManager(store, app);

--- a/src/core/LayoutUtils.js
+++ b/src/core/LayoutUtils.js
@@ -1,0 +1,3 @@
+export function getEntitySize(zoneWidth, zoneHeight, scale = 0.95) {
+  return Math.min(zoneWidth, zoneHeight) * scale;
+}

--- a/src/screens/GalaxyMap.js
+++ b/src/screens/GalaxyMap.js
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { store } from '../core/GameEngine.js';
+import { getEntitySize } from '../core/LayoutUtils.js';
 
 export class GalaxyMap extends PIXI.Container {
   constructor(app, manager) {
@@ -19,10 +20,10 @@ export class GalaxyMap extends PIXI.Container {
   renderMap(state) {
     this.mapLayer.removeChildren();
     const { width, height } = this.app.renderer;
-    const dim = Math.min(width, height);
+    const baseSize = getEntitySize(width, height);
     const count = state.sectors.length;
-    const ringRadius = dim * 0.35;
-    const radius = Math.max(36, dim * 0.09);
+    const ringRadius = baseSize * 0.35;
+    const radius = Math.max(36, baseSize * 0.09);
     const hexW = Math.sqrt(3) * radius;
     const hexH = 2 * radius;
 

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -4,6 +4,7 @@ import { store, stateManager } from '../core/GameEngine.js';
 import { weaponSystem } from '../core/WeaponSystem.js';
 import { PlanetMask } from '../core/PlanetMask.js';
 import { BrushManager } from '../core/BrushManager.js';
+import { getEntitySize } from '../core/LayoutUtils.js';
 
 export class MainScreen extends PIXI.Container {
   constructor(app) {
@@ -11,8 +12,8 @@ export class MainScreen extends PIXI.Container {
     this.screenId = 'MainScreen';
 
     const { width, height } = app.renderer;
-    const dim = Math.min(width, height);
-    this.radius = Math.max(dim * 0.28, 114);
+    const size = getEntitySize(width, height, 0.56);
+    this.radius = Math.max(size / 2, 114);
     this.app = app;
 
     this.planetContainer = new PIXI.Container();

--- a/src/screens/SectorMap.js
+++ b/src/screens/SectorMap.js
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { BlurFilter } from '@pixi/filter-blur';
 import { store } from '../core/GameEngine.js';
+import { getEntitySize } from '../core/LayoutUtils.js';
 
 export class SectorMap extends PIXI.Container {
   constructor(app, manager, params) {
@@ -36,7 +37,8 @@ export class SectorMap extends PIXI.Container {
     const zoneW = zoneRight - zoneLeft;
     const zoneH = zoneBottom - zoneTop;
 
-    const radius = Math.min(zoneW, zoneH) * 0.045;
+    const baseSize = getEntitySize(zoneW, zoneH, 0.09);
+    const radius = baseSize / 2;
     sector.entities.forEach((ent) => {
       const x = zoneLeft + (ent.position.x / 100) * zoneW;
       const y = zoneTop + (ent.position.y / 100) * zoneH;


### PR DESCRIPTION
## Summary
- adjust PIXI application to resize with the visible canvas container
- add a `getEntitySize` helper for consistent entity sizing
- use the helper in MainScreen, GalaxyMap and SectorMap

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68651d0fd3308322abf883a67b3bfdce