### PR TITLE
Fix UI positioning and remove Arsenal placeholder

### DIFF
--- a/src/screens/ArsenalLab.js
+++ b/src/screens/ArsenalLab.js
@@ -5,42 +5,9 @@ export class ArsenalLab extends PIXI.Container {
     super();
     this.screenId = 'Arsenal';
     this.app = app;
-    this.activeTab = 'weapons';
 
-    this.tabWeapons = new PIXI.Text('Weapons', { fill: 'white' });
-    this.tabUnits = new PIXI.Text('Units', { fill: 'white' });
-    this.tabWeapons.anchor.set(0.5);
-    this.tabUnits.anchor.set(0.5);
-    this.tabWeapons.y = 40;
-    this.tabUnits.y = 40;
-    this.tabWeapons.x = app.renderer.width / 2 - 60;
-    this.tabUnits.x = app.renderer.width / 2 + 60;
-    this.tabWeapons.eventMode = 'static';
-    this.tabUnits.eventMode = 'static';
-    this.tabWeapons.cursor = 'pointer';
-    this.tabUnits.cursor = 'pointer';
-    this.tabWeapons.on('pointertap', () => this.switchTab('weapons'));
-    this.tabUnits.on('pointertap', () => this.switchTab('units'));
-    this.addChild(this.tabWeapons, this.tabUnits);
-
-    this.content = new PIXI.Text('', { fill: 'yellow' });
-    this.content.anchor.set(0.5);
-    this.content.x = app.renderer.width / 2;
-    this.content.y = app.renderer.height / 2;
-    this.addChild(this.content);
-
-    this.updateTab();
-  }
-
-  switchTab(id) {
-    this.activeTab = id;
-    this.updateTab();
-  }
-
-  updateTab() {
-    this.tabWeapons.style.fill = this.activeTab === 'weapons' ? '#ff0' : '#fff';
-    this.tabUnits.style.fill = this.activeTab === 'units' ? '#ff0' : '#fff';
-    this.content.text =
-      this.activeTab === 'weapons' ? 'Weapons Tab' : 'Units Tab';
+    // The actual content of the Arsenal screen is rendered via React
+    // (`ArsenalWindow` component). This Pixi container remains empty
+    // to provide a background layer for the canvas scene.
   }
 }

--- a/src/ui/BackButton.tsx
+++ b/src/ui/BackButton.tsx
@@ -14,7 +14,8 @@ export const BackButton = () => {
 
   return (
     <button
-      className="absolute top-14 left-4 w-12 h-12 flex items-center justify-center z-60 pointer-events-auto"
+      className="absolute left-4 w-12 h-12 flex items-center justify-center z-60 pointer-events-auto"
+      style={{ top: 'calc(var(--hud-height) + 20px)' }}
       onClick={() => stateManager.goBack()}
     >
       <img src="/assets/ui/icon-back.svg" className="w-8 h-8 drop-shadow" />


### PR DESCRIPTION
## Summary
- align sector map Back button below HUD
- clean up ArsenalLab so Units tab shows real UI without placeholder text

## Testing
- `npm install`
- `npm run build`
- `npm run dev` *(fails to keep running as background task, server started)*

------
https://chatgpt.com/codex/tasks/task_e_68651f645668832291f210128b522d8b