### PR TITLE
Improve bottom nav mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     :root {
       --hud-height: 64px;
-      --navbar-height: 56px;
+      --navbar-height: calc(72px + env(safe-area-inset-bottom, 0px));
     }
     html, body {
       margin: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -10,19 +10,51 @@
 .navbar {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
   max-width: 414px;
   width: 100vw;
   margin: 0 auto;
-  overflow: hidden;
   box-sizing: border-box;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 8px;
+  padding-right: 8px;
+  gap: 8px;
 }
 
 .nav-button {
   flex: 1 1 20%;
   min-width: 44px;
-  max-width: 20%;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.nav-bg {
+  width: 48px;
+  height: 48px;
+  background: rgba(30, 41, 59, 0.85);
+  clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.nav-bg-main {
+  width: 60px;
+  height: 60px;
+  background: #6366f1;
+  clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 8px rgba(99, 102, 241, 0.8);
+  transform: translateY(-8px);
+  z-index: 1;
+}
+
+.nav-active {
+  background: #4f46e5;
+  box-shadow: 0 0 6px rgba(99, 102, 241, 0.6);
 }

--- a/src/ui/BottomNavBar.tsx
+++ b/src/ui/BottomNavBar.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { stateManager, store } from '../core/GameEngine.js';
 
+const isDev = import.meta.env.DEV;
+
 const buttons = [
   { id: 'Earn', label: 'Earn', icon: '/assets/ui/nav-earn.svg' },
   { id: 'Store', label: 'Store', icon: '/assets/ui/nav-store.svg' },
@@ -19,20 +21,35 @@ export const BottomNavBar = () => {
   }, []);
 
   return (
-    <nav className="navbar absolute bottom-0 left-0 right-0 bg-slate-800/70 border-t border-slate-700 text-white z-50 pointer-events-auto h-14 animate-fadeIn">
+    <nav
+      className="navbar absolute bottom-0 left-0 right-0 text-white z-50 pointer-events-auto animate-fadeIn"
+      style={{
+        height: 'calc(72px + env(safe-area-inset-bottom, 0px))',
+        paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)',
+      }}
+    >
       {buttons.map((btn) => {
         const isActive = btn.id === active;
+        const isMain = btn.id === 'MainScreen';
         return (
           <button
             key={btn.id}
-            className={`nav-button flex flex-col items-center transition-transform py-1 ${isActive ? 'bg-indigo-700 font-bold scale-105' : ''}`}
+            className="nav-button"
             onClick={() => stateManager.goTo(btn.id)}
           >
-            <img
-              src={btn.icon}
-              className={`${isActive ? 'w-10 h-10' : 'w-8 h-8'} mb-1 transition-transform`}
-            />
-            <span className="whitespace-nowrap overflow-hidden text-ellipsis text-[10px] mobile414:text-xs">{btn.label}</span>
+            <div
+              className={`${
+                isMain ? 'nav-bg-main' : 'nav-bg'
+              } ${isActive && !isMain ? 'nav-active' : ''} ${isDev ? 'debug-outline' : ''}`}
+            >
+              <img
+                src={btn.icon}
+                className={isMain ? 'w-10 h-10' : 'w-8 h-8'}
+              />
+            </div>
+            {!isMain && (
+              <span className="text-[12px] leading-none">{btn.label}</span>
+            )}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- redesign BottomNavBar layout to be mobile‑first
- give each nav button its own shaped background
- highlight MainScreen button and raise it slightly
- adjust global navbar height for safe-area

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865284c5f8c8322945d0816a6cafe77