### PR TITLE
Implement dispatch unit flow

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -19,7 +19,8 @@
     "iconNebula": "ui/icon-nebula.svg",
     "iconColony": "ui/icon-colony.svg",
     "iconGalaxy": "ui/icon-galaxy.svg",
-    "iconBack": "ui/icon-back.svg"
+    "iconBack": "ui/icon-back.svg",
+    "iconDispatch": "ui/icon-dispatch.svg"
   },
   "units": {
     "extractorIcon": "sprites/unit_extractor_idle.png",

--- a/assets/ui/icon-dispatch.svg
+++ b/assets/ui/icon-dispatch.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <rect x="6" y="20" width="36" height="8" fill="#4ade80" />
+  <polygon points="30,12 44,24 30,36" fill="#4ade80" />
+</svg>

--- a/docs/2-screens/popups/component-timer-bar.md
+++ b/docs/2-screens/popups/component-timer-bar.md
@@ -7,6 +7,7 @@ Timer Bar is a reusable UI component for displaying countdowns in a horizontal p
 
 ## 2. Usage Contexts
 - Dispatch mission countdowns (Planet Core extraction)
+- Dispatch list items in Arsenal and MainScreen
 - Active booster duration
 - Wheel of Fortune free ticket cooldown
 - Colony upkeep deadline

--- a/docs/2-screens/screen-arsenal.md
+++ b/docs/2-screens/screen-arsenal.md
@@ -14,3 +14,4 @@ Arsenal is the combined management hub for all equipment. It replaces the old Di
 
 ## Tabs
 - See `tab-weapons.md` and `tab-units.md` for details.
+- Units tab also displays all active dispatch missions and allows sending units to the selected planet.

--- a/docs/2-screens/screen-main.md
+++ b/docs/2-screens/screen-main.md
@@ -36,6 +36,7 @@ MainScreen is the core gameplay UI shown after entering a planet or Nebula. It‚Ä
 - **Central NavBar**: fixed bar (see global nav)
   - Center button = glowing planet icon
   - Highlights ‚ÄúMain‚Äù
+- **Dispatch List**: shows all active unit dispatches with timers and claim buttons
 
 ---
 
@@ -45,6 +46,7 @@ MainScreen is the core gameplay UI shown after entering a planet or Nebula. It‚Ä
 - On 0 HP:
   - Show Dust reward
   - Trigger dispatch panel for Core extraction
+  - Player selects a unit to dispatch
 
 ### 4.2. USDT Nebula
 - Integrity bar (not HP)

--- a/docs/2-screens/tab-units.md
+++ b/docs/2-screens/tab-units.md
@@ -6,8 +6,10 @@ Second tab of the Arsenal screen focused on unit management.
 - List of available units from `src/data/units.js` rendered via `UnitCard`.
 - Craft queue with timers for units in production.
 - Buttons to start crafting new units (uses `CreateUnitButton`).
+- Active dispatch list with timers and claim buttons.
 
 ## Logic
 - Calls `GameStateStore.startUnitCraft()` to craft units.
+- Calls `GameStateStore.startDispatch()` to send a unit to the selected planet.
 - Progress persists via `SaveManager`.
 - Replaces the functionality of the old Dispatch Center screen.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import './style.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { app, stateManager, store, dispatchSystem, nebulaSystem, colonySystem } from './core/GameEngine.js';
+import { app, stateManager, store, nebulaSystem, colonySystem } from './core/GameEngine.js';
 import { sectors as defaultSectors } from './data/galaxy.js';
 import { planetNames } from './data/planetNames.js';
 import { DevPanel } from './ui/DevPanel.tsx';
@@ -20,6 +20,8 @@ import { DustFlyout } from './ui/DustFlyout.tsx';
 import { ExtractionPanel } from './ui/ExtractionPanel.tsx';
 import { UnitReadyPopup } from './ui/UnitReadyPopup.tsx';
 import { ArsenalWindow } from './ui/ArsenalWindow.tsx';
+import { DispatchList } from './ui/DispatchList.tsx';
+import { DispatchModal } from './ui/DispatchModal.tsx';
 
 const isDev = import.meta.env.DEV;
 
@@ -51,6 +53,7 @@ function UI() {
   const [flyouts, setFlyouts] = React.useState<{ id: number; amount: number; idx: number }[]>([]);
   const flyoutIndex = React.useRef(0);
   const [screen, setScreen] = React.useState(store.get().currentScreen);
+  const [dispatchTarget, setDispatchTarget] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     const dustCb = ({ amount, source }: any) => {
@@ -115,13 +118,14 @@ function UI() {
       >
         <BackButton />
         <ExtractionPanel />
-        <WeaponPanel />
+        <WeaponPanel onDispatch={(id) => setDispatchTarget(id)} />
         <ColonyPanel />
         <GalaxyButton />
         <PlanetActionModal />
-      {flyouts.map((f) => (
-        <DustFlyout key={f.id} amount={f.amount} index={f.idx} />
-      ))}
+        <DispatchList />
+        {flyouts.map((f) => (
+          <DustFlyout key={f.id} amount={f.amount} index={f.idx} />
+        ))}
       {dustReward !== null && (
         <RewardDustPopup amount={dustReward} onClose={() => setDustReward(null)} />
       )}
@@ -154,6 +158,9 @@ function UI() {
           onUnlock={() => store.unlockSector(unlockId)}
         />
       )}
+      {dispatchTarget && (
+        <DispatchModal planetId={dispatchTarget} onClose={() => setDispatchTarget(null)} />
+      )}
       <ArsenalWindow />
       <DevPanel />
       </div>
@@ -174,13 +181,12 @@ root.render(<UI />);
 stateManager.goTo('MainScreen');
 
 setInterval(() => {
-  dispatchSystem.update();
   colonySystem.update();
-  store.updateExtractions();
+  store.updateDispatches();
   store.updateCraftQueue();
 }, 1000);
 
 // expose for debugging
-window.dispatchSystem = dispatchSystem;
+window.nebulaSystem = nebulaSystem;
 window.nebulaSystem = nebulaSystem;
 

--- a/src/ui/ArsenalWindow.tsx
+++ b/src/ui/ArsenalWindow.tsx
@@ -43,11 +43,36 @@ function UnitsTab() {
 
   const queue = Array.isArray(state.craftQueue) ? state.craftQueue : [];
   const units = state.units;
+  const dispatches = Array.isArray(state.dispatches) ? state.dispatches : [];
+  const planet = state.planet;
+  const canDispatch =
+    planet.status === 'destroyed' && dispatches.length < 3;
 
   const canCraft = queue.length < 3;
 
   return (
     <div className="flex flex-col gap-3">
+      {dispatches.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {dispatches.map((d) => {
+            const def = units.find((u) => u.id === d.unitId);
+            return (
+              <div key={d.id} className="bg-slate-800 p-2 rounded flex items-center gap-2">
+                <img src={def?.icon || '/assets/ui/placeholder.svg'} className="w-8 h-8" />
+                <div className="flex-1">
+                  <div className="text-white text-sm">{d.targetId}</div>
+                  <TimerBar startTime={d.startedAt} endTime={d.doneAt} />
+                </div>
+                {d.status === 'complete' && (
+                  <button className="bg-green-600 px-2 py-1 text-white rounded" onClick={() => store.claimDispatch(d.id)}>
+                    Claim
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
       {queue.length > 0 && (
         <div className="flex flex-col gap-2">
           {queue.map((q) => {
@@ -75,9 +100,18 @@ function UnitsTab() {
         </div>
       )}
       <div className="flex flex-col gap-2">
-        {units.map((u, idx) => (
-          <UnitCard key={idx} unit={u} />
-        ))}
+        {units.map((u, idx) => {
+          const busy = dispatches.some((d) => d.unitId === u.id);
+          return (
+            <UnitCard
+              key={idx}
+              unit={u}
+              onAction={canDispatch && !busy ? () => store.startDispatch(u.id, planet.id) : undefined}
+              actionLabel={busy ? 'Busy' : 'Dispatch'}
+              disabled={busy || !canDispatch}
+            />
+          );
+        })}
       </div>
       <div className="mt-2 flex flex-col gap-2">
         {unitData.map((u) => {

--- a/src/ui/DevPanel.tsx
+++ b/src/ui/DevPanel.tsx
@@ -71,9 +71,28 @@ export const DevPanel = () => {
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"
-              onClick={() => store.startExtraction(1000)}
+              onClick={() => {
+                const u = store.state.units.find((uu) => !uu.busy);
+                if (u) store.startDispatch(u.id, store.state.planet.id, 1000);
+              }}
             >
-              Force Extract
+              Instant Dispatch
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() => store.finishAllDispatches()}
+            >
+              Finish Dispatches
+            </button>
+            <button
+              className="bg-blue-500 px-2 py-1 mt-1"
+              onClick={() =>
+                store.state.dispatches.forEach((d) =>
+                  store.claimDispatch(d.id)
+                )
+              }
+            >
+              Claim Dispatches
             </button>
             <button
               className="bg-blue-500 px-2 py-1 mt-1"

--- a/src/ui/DispatchList.tsx
+++ b/src/ui/DispatchList.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { store } from '../core/GameEngine.js';
+import { TimerBar } from './TimerBar.tsx';
+
+const getPlanetName = (id: string, state: any) => {
+  for (const s of state.sectors) {
+    const p = s.entities.find((e: any) => e.id === id);
+    if (p) return p.name;
+  }
+  return id;
+};
+
+export const DispatchList = () => {
+  const [state, setState] = useState(store.get());
+
+  useEffect(() => {
+    const cb = (s: any) => setState({ ...s });
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
+  const list = Array.isArray(state.dispatches) ? state.dispatches : [];
+  if (list.length === 0) return null;
+
+  return (
+    <div className="absolute top-20 left-0 right-0 px-2 space-y-2 pointer-events-auto">
+      {list.map((d: any) => {
+        const unit = state.units.find((u: any) => u.id === d.unitId);
+        const planetName = getPlanetName(d.targetId, state);
+        return (
+          <div key={d.id} className="bg-slate-800 p-2 rounded flex items-center gap-2">
+            <img src={unit?.icon || '/assets/ui/placeholder.svg'} className="w-6 h-6" />
+            <div className="flex-1">
+              <div className="text-white text-xs">{planetName}</div>
+              <TimerBar startTime={d.startedAt} endTime={d.doneAt} color="#f59e0b" />
+            </div>
+            {d.status === 'complete' && (
+              <button className="bg-green-600 px-2 py-1 text-white rounded" onClick={() => store.claimDispatch(d.id)}>
+                Claim
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/ui/DispatchModal.tsx
+++ b/src/ui/DispatchModal.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { store } from '../core/GameEngine.js';
+import { UnitCard } from './UnitCard.tsx';
+
+interface Props {
+  planetId: string;
+  onClose: () => void;
+}
+
+export const DispatchModal = ({ planetId, onClose }: Props) => {
+  const [state, setState] = useState(store.get());
+
+  useEffect(() => {
+    const cb = (s: any) => setState({ ...s });
+    store.on('update', cb);
+    return () => store.off('update', cb);
+  }, []);
+
+  const available = state.units.filter((u: any) => !u.busy);
+
+  const send = (unit: any) => {
+    store.startDispatch(unit.id, planetId);
+    onClose();
+  };
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black/50 z-[200] pointer-events-auto">
+      <div className="bg-gray-800 p-4 rounded w-3/4 max-w-xs space-y-2" onClick={(e) => e.stopPropagation()}>
+        <div className="text-white text-center font-bold">Select Unit</div>
+        {available.length === 0 && (
+          <div className="text-center text-sm text-white">No available units</div>
+        )}
+        {available.map((u: any) => (
+          <UnitCard key={u.id} unit={u} onAction={() => send(u)} actionLabel="Send" />
+        ))}
+        <button className="mt-2 bg-red-600 text-white px-2 py-1 w-full rounded" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/ExtractionPanel.tsx
+++ b/src/ui/ExtractionPanel.tsx
@@ -17,7 +17,7 @@ export const ExtractionPanel = () => {
         p.extraction &&
         Date.now() >= p.extraction.startedAt + p.extraction.duration
       ) {
-        store.updateExtractions();
+        store.updateDispatches();
       }
       frame = requestAnimationFrame(loop);
     };
@@ -41,6 +41,14 @@ export const ExtractionPanel = () => {
         <div className="bg-blue-500 h-3" style={{ width: `${progress * 100}%` }}></div>
       </div>
       <div className="text-white text-sm mt-1 animate-pulse">{remaining}s</div>
+      {remaining === 0 && (
+        <button
+          className="mt-1 bg-green-600 text-white px-2 py-1 rounded pointer-events-auto"
+          onClick={() => planet.extraction && store.claimDispatch(planet.extraction.dispatchId)}
+        >
+          Claim
+        </button>
+      )}
     </div>
   );
 };

--- a/src/ui/WeaponPanel.tsx
+++ b/src/ui/WeaponPanel.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { weaponSystem } from '../core/WeaponSystem.js';
 import { store } from '../core/GameEngine.js';
 
-export const WeaponPanel = () => {
+interface Props {
+  onDispatch?: (planetId: string) => void;
+}
+
+export const WeaponPanel = ({ onDispatch }: Props) => {
   const [ammo, setAmmo] = useState(weaponSystem.weapon.ammo);
   const [planet, setPlanet] = useState(store.get().planet);
   const [screen, setScreen] = useState(store.get().currentScreen);
@@ -55,9 +59,7 @@ export const WeaponPanel = () => {
       {planet.status === 'destroyed' && (
         <button
           className="bg-green-600 text-white px-4 py-2 rounded w-32 h-12"
-          onClick={() => {
-            store.startExtraction();
-          }}
+          onClick={() => onDispatch && onDispatch(planet.id)}
         >
           Send Unit
         </button>


### PR DESCRIPTION
## Summary
- add dispatch state and methods in GameStateStore
- show dispatch timers and claim actions with DispatchList and ExtractionPanel
- allow sending units from WeaponPanel and Arsenal units tab
- extend DevPanel with dispatch controls
- document dispatch workflow in screen docs
- add placeholder dispatch icon and update manifest

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865474048f08322ab7cea9ce8964132