### PR TITLE
Refactor units UI

### DIFF
--- a/src/core/GameStateStore.js
+++ b/src/core/GameStateStore.js
@@ -33,6 +33,7 @@ export class GameStateStore {
       sectors: [],
       ui: {
         unlockSectorId: null,
+        arsenalTab: 'weapons',
       },
     };
     this.listeners = new Map();
@@ -372,6 +373,11 @@ export class GameStateStore {
 
   closeUnlockModal() {
     this.state.ui.unlockSectorId = null;
+    this.emit('update', this.state);
+  }
+
+  setArsenalTab(tab) {
+    this.state.ui.arsenalTab = tab;
     this.emit('update', this.state);
   }
 

--- a/src/ui/CreateUnitButton.tsx
+++ b/src/ui/CreateUnitButton.tsx
@@ -3,16 +3,17 @@ import React from 'react';
 interface Props {
   onClick: () => void;
   disabled?: boolean;
+  label?: string;
 }
 
-export const CreateUnitButton = ({ onClick, disabled }: Props) => {
+export const CreateUnitButton = ({ onClick, disabled, label = 'Build' }: Props) => {
   return (
     <button
       className="bg-green-600 text-white px-3 py-1 rounded disabled:opacity-50"
       onClick={onClick}
       disabled={disabled}
     >
-      Craft
+      {label}
     </button>
   );
 };

--- a/src/ui/DispatchModal.tsx
+++ b/src/ui/DispatchModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { store } from '../core/GameEngine.js';
-import { UnitCard } from './UnitCard.tsx';
+import { store, stateManager } from '../core/GameEngine.js';
+import { units as unitData } from '../data/units.js';
 
 interface Props {
   planetId: string;
@@ -17,23 +17,56 @@ export const DispatchModal = ({ planetId, onClose }: Props) => {
   }, []);
 
   const available = state.units.filter((u: any) => !u.busy);
+  const groups = available.reduce((acc: any, u: any) => {
+    acc[u.type] = acc[u.type] || [];
+    acc[u.type].push(u);
+    return acc;
+  }, {});
 
-  const send = (unit: any) => {
+  const send = (type: string) => {
+    const unit = groups[type]?.[0];
+    if (!unit) return;
     store.startDispatch(unit.id, planetId);
     onClose();
   };
 
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-black/50 z-[200] pointer-events-auto">
+      <div className="absolute left-4 w-12 h-12 flex items-center justify-center z-60 pointer-events-auto" style={{ top: 'calc(var(--hud-height) + 20px)' }} onClick={onClose}>
+        <img src="/assets/ui/icon-back.svg" className="w-8 h-8 drop-shadow" />
+      </div>
       <div className="bg-gray-800 p-4 rounded w-3/4 max-w-xs space-y-2" onClick={(e) => e.stopPropagation()}>
         <div className="text-white text-center font-bold">Select Unit</div>
-        {available.length === 0 && (
-          <div className="text-center text-sm text-white">No available units</div>
+        {Object.keys(groups).length === 0 && (
+          <>
+            <div className="text-center text-sm text-white">No available units</div>
+            <button
+              className="mt-2 bg-green-600 text-white px-2 py-1 w-full rounded"
+              onClick={() => {
+                store.setArsenalTab('units');
+                stateManager.goTo('Arsenal');
+                onClose();
+              }}
+            >
+              Buy
+            </button>
+          </>
         )}
-        {available.map((u: any) => (
-          <UnitCard key={u.id} unit={u} onAction={() => send(u)} actionLabel="Send" />
-        ))}
-        <button className="mt-2 bg-red-600 text-white px-2 py-1 w-full rounded" onClick={onClose}>Cancel</button>
+        {Object.keys(groups).map((type) => {
+          const def = unitData.find((d) => d.type === type);
+          const count = groups[type].length;
+          return (
+            <button
+              key={type}
+              className="bg-slate-800 p-2 rounded flex items-center gap-2 w-full text-left"
+              onClick={() => send(type)}
+            >
+              <img src={def?.icon || '/assets/ui/placeholder.svg'} className="w-8 h-8" />
+              <span className="flex-1 text-white">{def?.name || type}</span>
+              <span className="text-white text-sm">x{count}</span>
+            </button>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- store Arsenal tab state in GameStateStore
- update Units tab layout and remove dispatch button
- show unit counts and build buttons in one list
- improve DispatchModal with grouped units and Buy button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68654df09d988322920ef9ff92fdf395